### PR TITLE
Support measurement validation on more generic maps

### DIFF
--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/EnumObjectMapTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/EnumObjectMapTest.kt
@@ -26,8 +26,18 @@ class EnumObjectMapTest
     @Test
     fun can_enumerate_and_access_interface_members()
     {
-        val supportedTypes = SupportedTypes.map { it.key }
-        assertEquals( listOf( GeolocationType.typeName ), supportedTypes )
+        // Keys can be enumerated.
+        assertEquals( setOf( GeolocationType.typeName ), SupportedTypes.keys )
+
+        // Maps can be merged.
+        val additionalType = object : DataType { override val typeName: String = "additional-type" }
+        val additionalTypes =
+            object : EnumObjectMap<String, DataType>( { type -> type.typeName } )
+            {
+                val ADDITIONAL_TYPE = add( additionalType )
+            }
+        val mergedMap: Map<String, DataType> = SupportedTypes + additionalTypes
+        assertEquals( setOf( GeolocationType.typeName, additionalType.typeName ), mergedMap.keys )
     }
 
     @Test

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethods.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethods.kt
@@ -54,9 +54,9 @@ inline fun <reified TData : Data> measurement(
 
 /**
  * Determines whether [Data] and [DataTimeType] of [measurement] corresponds to the expected values for [DataType]
- * as determined by [DataTypeMetaDataMap], or [Trilean.UNKNOWN] in case the type of [DataType] is not registered.
+ * as determined by [DataTypeMetaData] in this map, or [Trilean.UNKNOWN] in case the type of [DataType] is not registered.
  */
-fun DataTypeMetaDataMap.isValidMeasurement( measurement: Measurement<*> ): Trilean
+fun Map<DataType, DataTypeMetaData>.isValidMeasurement( measurement: Measurement<*> ): Trilean
 {
     val expectedDataType = measurement.dataType
     val registeredType = this[ expectedDataType ] ?: return Trilean.UNKNOWN
@@ -70,12 +70,12 @@ fun DataTypeMetaDataMap.isValidMeasurement( measurement: Measurement<*> ): Trile
 }
 
 /**
- * Determines whether all [Measurement]s in [sequence] are valid as determined by [DataTypeMetaDataMap],
+ * Determines whether all [Measurement]s in [sequence] are valid as determined by [DataTypeMetaData] in this map,
  * and all timestamps are ordered correctly.
- * If data type isn't registered in [DataTypeMetaDataMap], [Trilean.UNKNOWN] is returned if measurements
+ * If data type isn't registered in this map, [Trilean.UNKNOWN] is returned if measurements
  * all share the same [DataTimeType] and are ordered correspondingly; [Trilean.FALSE] otherwise.
  */
-fun DataTypeMetaDataMap.isValidDataStreamSequence( sequence: DataStreamSequence<*> ): Trilean
+fun Map<DataType, DataTypeMetaData>.isValidDataStreamSequence( sequence: DataStreamSequence<*> ): Trilean
 {
     val expectedDataType = sequence.dataStream.dataType
     val registeredType: DataTypeMetaData? = this[ expectedDataType ]

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethodsTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethodsTest.kt
@@ -3,6 +3,9 @@ package dk.cachet.carp.data.infrastructure
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
+import dk.cachet.carp.common.application.data.DataTimeType
+import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.data.DataTypeMetaData
 import dk.cachet.carp.common.application.data.DataTypeMetaDataMap
 import dk.cachet.carp.common.infrastructure.test.STUB_DATA_POINT_TYPE
 import dk.cachet.carp.common.infrastructure.test.StubDataPoint
@@ -16,6 +19,7 @@ import dk.cachet.carp.data.application.stubDeploymentId
 import dk.cachet.carp.data.application.stubSequenceDeviceRoleName
 import dk.cachet.carp.data.application.stubSyncPoint
 import dk.cachet.carp.data.application.stubTriggerIds
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.*
 
@@ -180,5 +184,28 @@ class SerializerDerivedMethodsTest
 
         assertEquals( Trilean.FALSE, StubDataTypes.isValidDataStreamSequence( sequence ) )
         assertEquals( Trilean.FALSE, noRegistrations.isValidDataStreamSequence( sequence ) )
+    }
+
+    private object TestObjects
+    {
+        const val additionalTypeName = "some.namespace.additional_type"
+        val additionalType = DataType.fromString( additionalTypeName )
+    }
+
+    @Serializable
+    @SerialName( TestObjects.additionalTypeName )
+    data class AdditionalType( val ignore: String = "" ) : Data
+
+    @Test
+    fun validation_functions_can_operate_on_merged_maps()
+    {
+        val additionalType = DataType.fromString( TestObjects.additionalTypeName )
+        val additionalTypes = mapOf(
+            additionalType to DataTypeMetaData( additionalType, "Additional type", DataTimeType.POINT )
+        )
+        val mergedTypes = StubDataTypes + additionalTypes
+
+        val measurement = Measurement( 0, null, TestObjects.additionalType, AdditionalType() )
+        mergedTypes.isValidMeasurement( measurement )
     }
 }


### PR DESCRIPTION
This indirectly closes #389. For validation purposes, multiple `EnumObjectMap`s can easily be merged since that operation is supported on the base `Map` interface.

This was preferred over adding a `addAll` method on `EnumObjectMap` or extending classes, since it would only partially comply with the intent of `add` of these maps. The point is that not only `add` is called, but also that the result is stored in a local field to mimic an enum. This is not possible without manually constructing a new map which adds and assignes individual fields of other maps. But, this is not needed if the only use case is validation!