### PR TITLE
Allow handling concurrent `inviteNewParticipantGroup` calls

### DIFF
--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -126,12 +126,16 @@ class RecruitmentServiceHost(
             return recruitment.getParticipantGroupStatus( deployedStatus )
         }
 
-        // Create participant group, deploy, and send invitations.
+        // Create participant group and mark as deployed.
         val participantGroup = recruitment.addParticipantGroup( toDeployParticipantIds, uuidFactory.randomUUID() )
-        val deploymentStatus = deploymentService.createStudyDeployment( participantGroup.id, protocol, invitations )
         participantGroup.markAsDeployed()
-
         participantRepository.updateRecruitment( recruitment )
+
+        // Create study deployment, which sends out invitations.
+        // TODO: If the repository gets updated but `createStudyDeployment` fails, state will be inconsistent.
+        //  This should use eventual consistency: https://github.com/imotions/carp.core-kotlin/issues/295
+        //  And probably be separate requests: https://github.com/imotions/carp.core-kotlin/issues/319
+        val deploymentStatus = deploymentService.createStudyDeployment( participantGroup.id, protocol, invitations )
 
         return recruitment.getParticipantGroupStatus( deploymentStatus )
     }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -129,7 +129,7 @@ class RecruitmentServiceHost(
         // Create participant group, deploy, and send invitations.
         val participantGroup = recruitment.addParticipantGroup( toDeployParticipantIds, uuidFactory.randomUUID() )
         val deploymentStatus = deploymentService.createStudyDeployment( participantGroup.id, protocol, invitations )
-        participantGroup.markAsInvited( deploymentStatus )
+        participantGroup.markAsDeployed()
 
         participantRepository.updateRecruitment( recruitment )
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroup.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroup.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.deployments.application.StudyDeploymentStatus
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 
@@ -23,16 +21,10 @@ data class StagedParticipantGroup(
         get() = _participantIds
 
     /**
-     * The time at which the participant group was invited.
-     */
-    var invitedOn: Instant? = null
-        private set
-
-    /**
      * Determines whether this participant group has been deployed.
      */
-    val isDeployed: Boolean
-        get() = invitedOn != null
+    var isDeployed: Boolean = false
+        private set
 
 
 
@@ -50,15 +42,14 @@ data class StagedParticipantGroup(
     }
 
     /**
-     * Specify that a deployment with [deploymentStatus] for this participant group has been created,
-     * and thus the participants have been invited.
+     * Specify that a deployment for this participant group has been created.
      *
-     * @throws IllegalStateException when no participants to invite are specified.
+     * @throws IllegalStateException when no participants to deploy are specified.
      */
-    fun markAsInvited( deploymentStatus: StudyDeploymentStatus )
+    fun markAsDeployed()
     {
         check( participantIds.isNotEmpty() ) { "No participants specified to deploy." }
 
-        invitedOn = deploymentStatus.createdOn
+        isDeployed = true
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroupTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroupTest.kt
@@ -28,37 +28,29 @@ class StagedParticipantGroupTest
         val group = StagedParticipantGroup()
         val participantId = UUID.randomUUID()
         group.addParticipants( setOf( participantId ) )
-        val stubInvitedStatus =
-            StudyDeploymentStatus.Invited( Clock.System.now(), UUID.randomUUID(), emptyList(), emptyList(), Clock.System.now() )
-        group.markAsInvited( stubInvitedStatus )
+        group.markAsDeployed()
 
         val newParticipantId = UUID.randomUUID()
         assertFailsWith<IllegalStateException> { group.addParticipants( setOf( newParticipantId ) ) }
     }
 
     @Test
-    fun markAsInvited_succeeds()
+    fun markAsDeployed_succeeds()
     {
         val group = StagedParticipantGroup()
         val participantId = UUID.randomUUID()
         group.addParticipants( setOf( participantId ) )
         assertFalse( group.isDeployed )
 
-        val expectedInvitedOn: Instant = Clock.System.now()
-        val mockInvitedStatus =
-            StudyDeploymentStatus.Invited( expectedInvitedOn, UUID.randomUUID(), emptyList(), emptyList(), Clock.System.now() )
-        group.markAsInvited( mockInvitedStatus )
+        group.markAsDeployed()
 
-        assertEquals( expectedInvitedOn, group.invitedOn )
         assertTrue( group.isDeployed )
     }
 
     @Test
-    fun markAsInvited_fails_when_no_participants_are_added()
+    fun markAsDeployed_fails_when_no_participants_are_added()
     {
         val group = StagedParticipantGroup()
-        val stubInvitedStatus =
-            StudyDeploymentStatus.Invited( Clock.System.now(), UUID.randomUUID(), emptyList(), emptyList(), Clock.System.now() )
-        assertFailsWith<IllegalStateException> { group.markAsInvited( stubInvitedStatus ) }
+        assertFailsWith<IllegalStateException> { group.markAsDeployed() }
     }
 }


### PR DESCRIPTION
Currently, when concurrent `RecruitmentService.inviteNewParticipantGroup` requests are allowed, requests can override changes to `Recruitment`: added participant groups (linking to study deployments) may go missing.

The ideal solution to fix this would be to have these requests be eventually consistent (#295), or not have the single request at all but rely on separate requests (#319). However, these would be breaking changes and could only be rolled out in the next major release.

Until then, this PR allows infrastructures to prevent sending out invitations in case of concurrent calls to `inviteNewParticipantGroup`. Concurrent modifications can be detected by the repository implementation, which should then throw an exception, at which point no deployment will be created.

These changes may still cause inconsistent state across subsystems in case the `deploymentService.createStudyDeployment` call fails, which is why this request should be deprecated in future releases.