### PR TITLE
Fix: snapshot load for deployment with unregistered connected device

### DIFF
--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -94,18 +94,14 @@ class StudyDeployment private constructor(
                 }
 
                 // In case snapshot indicates the device is currently not registered, unregister it.
-                if ( roleName !in snapshot.registeredDevices )
-                {
-                    deployment.unregisterDevice( device )
-                }
+                if ( roleName !in snapshot.registeredDevices ) deployment.unregisterDevice( device )
             }
 
             // Add deployed devices.
             snapshot.deployedDevices.forEach { roleName ->
                 val deployedDevice = deployment.protocolSnapshot.primaryDevices.firstOrNull { it.roleName == roleName }
                     ?: throw IllegalArgumentException( "Can't find deployed device with role name '$roleName' in snapshot." )
-                val deviceDeployment = deployment.getDeviceDeploymentFor( deployedDevice )
-                deployment.deviceDeployed( deployedDevice, deviceDeployment.lastUpdatedOn )
+                deployment._deployedDevices.add( deployedDevice )
             }
 
             // Add invalidated deployed devices.
@@ -450,7 +446,8 @@ class StudyDeployment private constructor(
     fun deviceDeployed( device: AnyPrimaryDeviceConfiguration, deviceDeploymentLastUpdatedOn: Instant )
     {
         // Verify whether the specified device is part of the protocol of this deployment.
-        require( device in protocolSnapshot.primaryDevices ) { "The specified primary device is not part of the protocol of this deployment." }
+        require( device in protocolSnapshot.primaryDevices )
+            { "The specified primary device is not part of the protocol of this deployment." }
 
         // Verify whether deployment matches the expected deployment.
         val latestDeployment = getDeviceDeploymentFor( device )
@@ -463,7 +460,8 @@ class StudyDeployment private constructor(
             it is DeviceDeploymentStatus.Deployed ||
             it is DeviceDeploymentStatus.NotDeployed && it.isReadyForDeployment
         }
-        check( canDeploy ) { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
+        check( canDeploy )
+            { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
 
         _deployedDevices
             .add( device )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceTest.kt
@@ -29,9 +29,7 @@ interface DeploymentServiceTest
     @Test
     fun createStudyDeployment_registers_preregistered_devices() = runTest {
         val deploymentService = createService()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
-        val primaryDevice = protocol.primaryDevices.single()
-        val connectedDevice = protocol.getConnectedDevices( primaryDevice ).single()
+        val (protocol, primaryDevice, connectedDevice) = createSinglePrimaryWithConnectedDeviceProtocol()
 
         val deploymentId = UUID.randomUUID()
         val preregistration = connectedDevice.createRegistration()
@@ -109,7 +107,7 @@ interface DeploymentServiceTest
     fun getStudyDeploymentStatusList_succeeds() = runTest {
         val deploymentService = createService()
         val deviceRoleName = "Primary"
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( deviceRoleName )
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol( deviceRoleName )
         val protocolSnapshot = protocol.getSnapshot()
 
         val invitation1 = createParticipantInvitation( AccountIdentity.fromUsername( "User 1" ) )
@@ -222,7 +220,8 @@ interface DeploymentServiceTest
         connectedDeviceRoleName: String = "Connected"
     ): UUID
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( primaryDeviceRoleName, connectedDeviceRoleName )
+        val (protocol, _, _) =
+            createSinglePrimaryWithConnectedDeviceProtocol( primaryDeviceRoleName, connectedDeviceRoleName )
         val invitation = createParticipantInvitation()
         val studyDeploymentId = UUID.randomUUID()
         deploymentService.createStudyDeployment( studyDeploymentId, protocol.getSnapshot(), listOf( invitation ) )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
@@ -110,13 +110,12 @@ class ValidationTest
     {
         val primaryRoleName = "Primary"
         val connectedRoleName = "Connected"
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( primaryRoleName, connectedRoleName ).getSnapshot()
+        val (protocol, _, connected) =
+            createSinglePrimaryWithConnectedDeviceProtocol( primaryRoleName, connectedRoleName )
 
-        val preregistrations = mapOf(
-            connectedRoleName to protocol.connectedDevices.first { it.roleName == connectedRoleName }.createRegistration()
-        )
-
-        protocol.throwIfInvalidPreregistrations( preregistrations )
+        val preregistrations = mapOf( connectedRoleName to connected.createRegistration() )
+        val protocolSnapshot = protocol.getSnapshot()
+        protocolSnapshot.throwIfInvalidPreregistrations( preregistrations )
     }
 
     @Test
@@ -124,14 +123,13 @@ class ValidationTest
     {
         val primaryRoleName = "Primary"
         val connectedRoleName = "Connected"
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( primaryRoleName, connectedRoleName ).getSnapshot()
+        val (protocol, primary, _) =
+            createSinglePrimaryWithConnectedDeviceProtocol( primaryRoleName, connectedRoleName )
 
-        val preregistrations = mapOf(
-            primaryRoleName to protocol.primaryDevices.first { it.roleName == primaryRoleName }.createRegistration()
-        )
-
+        val preregistrations = mapOf( primaryRoleName to primary.createRegistration() )
+        val protocolSnapshot = protocol.getSnapshot()
         assertFailsWith<IllegalArgumentException> {
-            protocol.throwIfInvalidPreregistrations( preregistrations )
+            protocolSnapshot.throwIfInvalidPreregistrations( preregistrations )
         }
     }
 
@@ -153,7 +151,7 @@ class ValidationTest
     {
         val primaryRoleName = "Primary"
         val connectedRoleName = "Connected"
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( primaryRoleName, connectedRoleName ).getSnapshot()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol( primaryRoleName, connectedRoleName )
 
         val invalidRegistration =
             object : DeviceRegistration()
@@ -163,8 +161,9 @@ class ValidationTest
             }
         val preregistrations = mapOf( connectedRoleName to invalidRegistration )
 
+        val protocolSnapshot = protocol.getSnapshot()
         assertFailsWith<IllegalArgumentException> {
-            protocol.throwIfInvalidPreregistrations( preregistrations )
+            protocolSnapshot.throwIfInvalidPreregistrations( preregistrations )
         }
     }
 }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/CreateTestObjects.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/CreateTestObjects.kt
@@ -5,7 +5,6 @@ import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.CustomInput
 import dk.cachet.carp.common.application.data.input.Sex
 import dk.cachet.carp.common.application.data.input.elements.Text
-import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
@@ -43,12 +42,10 @@ fun studyDeploymentFor( protocol: StudyProtocol ): StudyDeployment
  */
 fun createComplexDeployment(): StudyDeployment
 {
-    val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
+    val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
     val deployment = studyDeploymentFor( protocol )
 
     // Add device registrations.
-    val primary = deployment.registrableDevices.first { it.device.roleName == "Primary" }.device as AnyPrimaryDeviceConfiguration
-    val connected = deployment.registrableDevices.first { it.device.roleName == "Connected" }.device
     deployment.registerDevice( primary, primary.createRegistration() )
     deployment.registerDevice( connected, connected.createRegistration() )
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/DeploymentRepositoryTest.kt
@@ -23,7 +23,7 @@ interface DeploymentRepositoryTest
     @Test
     fun adding_study_deployment_and_retrieving_it_succeeds() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
 
         repo.add( deployment )
@@ -36,7 +36,7 @@ interface DeploymentRepositoryTest
     @Test
     fun adding_study_deployment_with_existing_id_fails() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         repo.add( deployment )
 
@@ -49,7 +49,7 @@ interface DeploymentRepositoryTest
     @Test
     fun getStudyDeploymentBy_succeeds() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         repo.add( deployment )
 
@@ -69,7 +69,7 @@ interface DeploymentRepositoryTest
     @Test
     fun getStudyDeploymentsBy_succeeds() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment1 = studyDeploymentFor( protocol )
         val deployment2 = studyDeploymentFor( protocol )
         repo.add( deployment1 )
@@ -84,7 +84,7 @@ interface DeploymentRepositoryTest
     @Test
     fun getStudyDeploymentsBy_ignores_unknown_ids() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         repo.add( deployment )
 
@@ -96,11 +96,9 @@ interface DeploymentRepositoryTest
     @Test
     fun update_study_deployment_succeeds() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, primaryDevice, connectedDevice) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         repo.add( deployment )
-        val primaryDevice = protocol.primaryDevices.first()
-        val connectedDevice = protocol.getConnectedDevices( primaryDevice ).first()
 
         // Perform various actions on deployment, modifying it.
         // TODO: This does not verify whether registration history and invalidated devices are updated.
@@ -124,7 +122,7 @@ interface DeploymentRepositoryTest
     @Test
     fun update_study_deployment_fails_for_unknown_deployment() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
 
         assertFailsWith<IllegalArgumentException>
@@ -136,7 +134,7 @@ interface DeploymentRepositoryTest
     @Test
     fun remove_succeeds() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment1 = studyDeploymentFor( protocol )
         val deployment2 = studyDeploymentFor( protocol )
         repo.add( deployment1 )
@@ -154,7 +152,7 @@ interface DeploymentRepositoryTest
     @Test
     fun remove_igores_unknown_ids() = runTest {
         val repo = createRepository()
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         repo.add( deployment )
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentTest.kt
@@ -86,7 +86,7 @@ class StudyDeploymentTest
     @Test
     fun new_deployment_has_unregistered_primary_device()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, primary, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         // Two devices can be registered, but none are by default.
@@ -96,7 +96,7 @@ class StudyDeploymentTest
 
         // Only the primary device requires deployment.
         val requiredDeployment = deployment.registrableDevices.single { it.requiresDeployment }
-        assertEquals( protocol.primaryDevices.single(), requiredDeployment.device )
+        assertEquals( primary, requiredDeployment.device )
     }
 
     @Test
@@ -182,7 +182,7 @@ class StudyDeploymentTest
     @Test
     fun cant_registerDevice_not_part_of_deployment()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         val invalidDevice = StubPrimaryDeviceConfiguration( "Not part of deployment" )
@@ -315,10 +315,7 @@ class StudyDeploymentTest
     fun unregisterDevice_for_connected_device_succeeds()
     {
         // Create deployment with registered devices.
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary: AnyPrimaryDeviceConfiguration =
-            protocol.devices.first { it.roleName == "Primary" } as AnyPrimaryDeviceConfiguration
-        val connected = protocol.devices.first { it.roleName == "Connected" }
+        val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
         deployment.registerDevice( primary, primary.createRegistration() )
         deployment.registerDevice( connected, connected.createRegistration() )
@@ -366,9 +363,8 @@ class StudyDeploymentTest
     @Test
     fun unregisterDevice_fails_for_device_not_part_of_deployment()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, primary, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
-        val primary = protocol.devices.first { it is AnyPrimaryDeviceConfiguration }
 
         assertFailsWith<IllegalArgumentException> { deployment.unregisterDevice( primary ) }
     }
@@ -376,7 +372,7 @@ class StudyDeploymentTest
     @Test
     fun unregisterDevice_fails_for_device_which_is_not_registered()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         val invalidDevice = StubPrimaryDeviceConfiguration( "Not part of deployment" )
@@ -441,10 +437,7 @@ class StudyDeploymentTest
     fun fromSnapshot_succeeds_for_deployed_device_with_unregistered_connected_devices()
     {
         // Create deployment.
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary: AnyPrimaryDeviceConfiguration =
-            protocol.devices.first { it.roleName == "Primary" } as AnyPrimaryDeviceConfiguration
-        val connected = protocol.devices.first { it.roleName == "Connected" }
+        val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         // Deploy device.
@@ -486,9 +479,7 @@ class StudyDeploymentTest
     @Test
     fun getStatus_lifecycle_primary_and_connected()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary = protocol.devices.first { it.roleName == "Primary" } as AnyPrimaryDeviceConfiguration
-        val connected = protocol.devices.first { it.roleName == "Connected" }
+        val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         // Start of deployment, no devices registered.
@@ -600,10 +591,8 @@ class StudyDeploymentTest
     @Test
     fun getDeviceDeploymentFor_succeeds()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
+        val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
         protocol.applicationData = "some data"
-        val primary = protocol.primaryDevices.first { it.roleName == "Primary" }
-        val connected = protocol.devices.first { it.roleName == "Connected" }
         val primaryTask = StubTaskConfiguration( "Primary task" )
         val connectedTask = StubTaskConfiguration( "Connected task" )
         protocol.addTaskControl( primary.atStartOfStudy().start( primaryTask, primary ) )
@@ -643,9 +632,7 @@ class StudyDeploymentTest
     @Test
     fun getDeviceDeploymentFor_with_preregistered_device_succeeds()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary = protocol.primaryDevices.first { it.roleName == "Primary" }
-        val connected = protocol.devices.first { it.roleName == "Connected" }
+        val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         deployment.registerDevice( primary, DefaultDeviceRegistration() )
 
@@ -660,8 +647,7 @@ class StudyDeploymentTest
     @Test
     fun getDeviceDeploymentFor_without_preregistered_device_succeeds()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary = protocol.primaryDevices.first { it.roleName == "Primary" }
+        val (protocol, primary, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         deployment.registerDevice( primary, DefaultDeviceRegistration() )
 
@@ -734,7 +720,7 @@ class StudyDeploymentTest
     @Test
     fun getDeviceDeploymentFor_fails_when_device_not_in_protocol()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
 
         assertFailsWith<IllegalArgumentException>
@@ -746,8 +732,7 @@ class StudyDeploymentTest
     @Test
     fun getDeviceDeploymentFor_fails_when_device_cant_be_deployed_yet()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary = protocol.primaryDevices.first { it.roleName == "Primary" }
+        val (protocol, primary, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
 
         assertFailsWith<IllegalStateException> { deployment.getDeviceDeploymentFor( primary ) }
@@ -841,8 +826,7 @@ class StudyDeploymentTest
     @Test
     fun deviceDeployed_fails_when_connected_device_is_unregistered()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary = protocol.primaryDevices.first { it.roleName == "Primary" }
+        val (protocol, primary, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         deployment.registerDevice( primary, DefaultDeviceRegistration() )
         val deviceDeployment = deployment.getDeviceDeploymentFor( primary )
@@ -914,9 +898,7 @@ class StudyDeploymentTest
     @Test
     fun modifications_after_stop_not_allowed()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol( "Primary", "Connected" )
-        val primary = protocol.primaryDevices.first { it.roleName == "Primary" }
-        val connected = protocol.devices.first { it.roleName == "Connected" }
+        val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         deployment.registerDevice( primary, primary.createRegistration() )
         deployment.registerDevice( connected, connected.createRegistration() )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
@@ -36,8 +36,7 @@ class StudyDeploymentStatusTest
     @Test
     fun can_serialize_and_deserialize_deployment_status_using_JSON()
     {
-        val protocol = createSinglePrimaryWithConnectedDeviceProtocol()
-        val primary = protocol.primaryDevices.single()
+        val (protocol, primary, _) = createSinglePrimaryWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         deployment.registrableDevices.forEach {
             deployment.registerDevice( it.device, it.device.createRegistration() )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
@@ -3,6 +3,9 @@ package dk.cachet.carp.protocols.infrastructure.test
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.InputDataType
+import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
+import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
+import dk.cachet.carp.common.application.devices.PrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.tasks.Measure
 import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.application.users.AssignedTo
@@ -49,14 +52,22 @@ fun createSinglePrimaryDeviceProtocol( primaryDeviceName: String = "Primary" ): 
 fun createSinglePrimaryWithConnectedDeviceProtocol(
     primaryDeviceName: String = "Primary",
     connectedDeviceName: String = "Connected"
-): StudyProtocol
+): SinglePrimaryWithConnectedTestProtocol
 {
     val protocol = createEmptyProtocol()
     val primary = StubPrimaryDeviceConfiguration( primaryDeviceName )
     protocol.addPrimaryDevice( primary )
-    protocol.addConnectedDevice( StubDeviceConfiguration( connectedDeviceName ), primary )
-    return protocol
+    val connected = StubDeviceConfiguration( connectedDeviceName )
+    protocol.addConnectedDevice( connected, primary )
+
+    return SinglePrimaryWithConnectedTestProtocol( protocol, primary, connected )
 }
+
+data class SinglePrimaryWithConnectedTestProtocol(
+    val protocoL: StudyProtocol,
+    val primary: AnyPrimaryDeviceConfiguration,
+    val connected: AnyDeviceConfiguration
+)
 
 /**
  * Creates a study protocol with a couple of devices and tasks added.


### PR DESCRIPTION
Loading a `StudyDeployment` which had an unregistered connected device failed since to deploy a device (`deviceDeployed`), all required devices needed to be registered, and, when loading the snapshot `deviceDeployed` was called. This call failed after replaying the deployment's registration history and not all necessary devices were registered.

`deviceDeployed` was called as a way to ensure preconditions were checked. In this case, preconditions were checked incorrectly by doing so (a device can be deployed with connected devices unregistered _after_ it has been deployed). The fix is to manipulate the `StudyDeployment` state directly, while still verifying snapshot correctness.

Also refactored test code a bit to remove redundant retrieval of the primary and connected device in the study protocols used for tests.