### PR TITLE
Interval sampling constraints

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -140,4 +140,22 @@ class SmartphoneSamplingConfigurationMapBuilder : SamplingConfigurationMapBuilde
      */
     fun geolocation( builder: AdaptiveGranularitySamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
         addConfiguration( Smartphone.Sensors.GEOLOCATION, builder )
+
+    /**
+     * Configure sampling configuration for [CarpDataTypes.NON_GRAVITATIONAL_ACCELERATION].
+     */
+    fun nonGravitationalAcceleration( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+        addConfiguration( Smartphone.Sensors.NON_GRAVITATIONAL_ACCELERATION, builder )
+
+    /**
+     * Configure sampling configuration for [CarpDataTypes.ACCELERATION].
+     */
+    fun acceleration( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+        addConfiguration( Smartphone.Sensors.ACCELERATION, builder )
+
+    /**
+     * Configure sampling configuration for [CarpDataTypes.ANGULAR_VELOCITY].
+     */
+    fun angularVelocity( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+        addConfiguration( Smartphone.Sensors.ANGULAR_VELOCITY, builder )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
@@ -10,16 +10,33 @@ import kotlin.time.Duration
 /**
  * Sampling scheme which allows configuring a time interval in between subsequent measurements.
  */
-class IntervalSamplingScheme( dataType: DataTypeMetaData, val defaultMeasureInterval: Duration ) :
-    DataTypeSamplingScheme<IntervalSamplingConfigurationBuilder>(
-        dataType,
-        IntervalSamplingConfiguration( defaultMeasureInterval )
-    )
+class IntervalSamplingScheme(
+    dataType: DataTypeMetaData,
+    val defaultMeasureInterval: Duration,
+    /**
+     * A fixed set of [Duration] options which are valid; null if no such restriction exists.
+     */
+    val validOptions: Set<Duration>? = null
+) : DataTypeSamplingScheme<IntervalSamplingConfigurationBuilder>(
+    dataType,
+    IntervalSamplingConfiguration( defaultMeasureInterval )
+)
 {
+    init
+    {
+        if ( validOptions != null )
+        {
+            require( defaultMeasureInterval in validOptions )
+                { "If only a fixed set of options are valid, the default interval needs to be one of the options." }
+        }
+    }
+
     override fun createSamplingConfigurationBuilder(): IntervalSamplingConfigurationBuilder =
         IntervalSamplingConfigurationBuilder( defaultMeasureInterval )
 
-    override fun isValid( configuration: SamplingConfiguration ) = configuration is IntervalSamplingConfiguration
+    override fun isValid( configuration: SamplingConfiguration ) =
+        configuration is IntervalSamplingConfiguration &&
+        ( validOptions == null || configuration.interval in validOptions )
 }
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingSchemeTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingSchemeTest.kt
@@ -19,7 +19,7 @@ class DataTypeSamplingSchemeTest
         val maxDuration: Duration = 42.seconds
 
         override fun createSamplingConfigurationBuilder(): IntervalSamplingConfigurationBuilder =
-            IntervalSamplingConfigurationBuilder( 5.seconds )
+            IntervalSamplingConfigurationBuilder( 5.seconds, null )
 
         override fun isValid( configuration: SamplingConfiguration ): Boolean =
             configuration is IntervalSamplingConfiguration && configuration.interval <= maxDuration

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/IntervalSamplingTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/IntervalSamplingTest.kt
@@ -22,6 +22,12 @@ class IntervalSamplingSchemeTest
     }
 
     @Test
+    fun at_least_one_option_needed()
+    {
+        assertFailsWith<IllegalArgumentException> { IntervalSamplingScheme( dataType, 50.milliseconds, emptySet() ) }
+    }
+
+    @Test
     fun isValid_true_when_no_constraints_are_set()
     {
         val noConstraints = IntervalSamplingScheme( dataType, 100.milliseconds )
@@ -46,5 +52,31 @@ class IntervalSamplingSchemeTest
         val constrainedOptions = IntervalSamplingScheme( dataType, options.first(), options )
 
         assertFalse( constrainedOptions.isValid( IntervalSamplingConfiguration( 200.milliseconds ) ) )
+    }
+}
+
+
+/**
+ * Tests for [IntervalSamplingConfigurationBuilder].
+ */
+class IntervalSamplingConfigurationBuilderTest
+{
+    @Test
+    fun nearestOption_without_options()
+    {
+        val builder = IntervalSamplingConfigurationBuilder( 50.milliseconds, null )
+
+        assertEquals( 42.milliseconds, builder.nearestOption( 42.milliseconds ) )
+    }
+
+    @Test
+    fun nearestOption_selects_nearest_option_when_options_are_set()
+    {
+        val options = setOf( 50.milliseconds, 100.milliseconds )
+        val builder = IntervalSamplingConfigurationBuilder( 50.milliseconds, options )
+
+        assertEquals( 50.milliseconds, builder.nearestOption( 50.milliseconds ) )
+        assertEquals( 50.milliseconds, builder.nearestOption( 0.milliseconds ) )
+        assertEquals( 100.milliseconds, builder.nearestOption( 90.milliseconds ) )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/IntervalSamplingTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/IntervalSamplingTest.kt
@@ -1,0 +1,50 @@
+@file:Suppress( "MatchingDeclarationName" )
+
+package dk.cachet.carp.common.application.sampling
+
+import dk.cachet.carp.common.infrastructure.test.StubDataTypes
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+
+/**
+ * Tests for [IntervalSamplingScheme].
+ */
+class IntervalSamplingSchemeTest
+{
+    private val dataType = StubDataTypes.STUB_POINT
+
+    @Test
+    fun default_interval_needs_to_be_in_options()
+    {
+        val options = setOf( 100.milliseconds )
+        assertFailsWith<IllegalArgumentException> { IntervalSamplingScheme( dataType, 50.milliseconds, options ) }
+    }
+
+    @Test
+    fun isValid_true_when_no_constraints_are_set()
+    {
+        val noConstraints = IntervalSamplingScheme( dataType, 100.milliseconds )
+        assertTrue( noConstraints.isValid( IntervalSamplingConfiguration( 0.milliseconds ) ) )
+    }
+
+    @Test
+    fun isValid_true_when_value_in_options()
+    {
+        val options = setOf( 50.milliseconds, 100.milliseconds )
+        val constrainedOptions = IntervalSamplingScheme( dataType, options.first(), options )
+
+        options.forEach {
+            assertTrue( constrainedOptions.isValid( IntervalSamplingConfiguration( it ) ) )
+        }
+    }
+
+    @Test
+    fun isValid_false_when_value_not_in_options()
+    {
+        val options = setOf( 50.milliseconds, 100.milliseconds )
+        val constrainedOptions = IntervalSamplingScheme( dataType, options.first(), options )
+
+        assertFalse( constrainedOptions.isValid( IntervalSamplingConfiguration( 200.milliseconds ) ) )
+    }
+}


### PR DESCRIPTION
For measures which support configuring an _interval_ at which to collect data, the introduced changes now support setting a fixed set of interval options in the corresponding sampling scheme.

In addition, while adding the `nearestOption` helper method to the interval sampling configuration builder, I noticed that the `Smartphone` sampling configuration builder did not yet expose accelerometry and angular velocity configurations.