### PR TITLE
Fix: redeploying devices incorrectly opened data streams

### DIFF
--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -126,6 +126,7 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [primaryDeviceRoleName] is not present in the deployment
+     * - the device with [primaryDeviceRoleName] has not yet been registered
      * @throws IllegalStateException when the deployment for the requested primary device is not yet available.
      */
     suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, primaryDeviceRoleName: String ): PrimaryDeviceDeployment

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
@@ -179,6 +179,7 @@ class DeploymentServiceHost(
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [primaryDeviceRoleName] is not present in the deployment
+     * - the device with [primaryDeviceRoleName] has not yet been registered
      * @throws IllegalStateException when the deployment for the requested primary device is not yet available.
      */
     override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, primaryDeviceRoleName: String ): PrimaryDeviceDeployment

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
@@ -213,15 +213,15 @@ class DeploymentServiceHost(
         deployment.deviceDeployed( device, deviceDeploymentLastUpdatedOn )
         repository.update( deployment )
 
-        val deploymentStatus = deployment.getStatus()
-
-        // Once the deployment is running, open the required data streams.
-        if ( deploymentStatus is StudyDeploymentStatus.Running )
+        // Open the required data streams.
+        try { dataStreamService.openDataStreams( deployment.requiredDataStreams ) }
+        catch( ignore: IllegalStateException )
         {
-            dataStreamService.openDataStreams( deployment.requiredDataStreams )
+            // Upon re-deployments this may throw an exception indicating streams have already been opened.
+            // This can safely be ignored, since this is the goal of this call.
         }
 
-        return deploymentStatus
+        return deployment.getStatus()
     }
 
     /**

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHostTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHostTest.kt
@@ -15,7 +15,7 @@ class DeploymentServiceHostTest : DeploymentServiceTest
 {
     companion object
     {
-        fun createService(): DeploymentServiceTest.DependentServices
+        fun createSUT(): DeploymentServiceTest.SUT
         {
             val eventBus: EventBus = SingleThreadedEventBus()
 
@@ -26,9 +26,9 @@ class DeploymentServiceHostTest : DeploymentServiceTest
                 TestClock
             )
 
-            return DeploymentServiceTest.DependentServices( deploymentService, eventBus )
+            return DeploymentServiceTest.SUT( deploymentService, eventBus )
         }
     }
 
-    override fun createService(): DeploymentServiceTest.DependentServices = DeploymentServiceHostTest.createService()
+    override fun createSUT(): DeploymentServiceTest.SUT = DeploymentServiceHostTest.createSUT()
 }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHostTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHostTest.kt
@@ -15,7 +15,7 @@ class DeploymentServiceHostTest : DeploymentServiceTest
 {
     companion object
     {
-        fun createService(): Pair<DeploymentService, EventBus>
+        fun createService(): DeploymentServiceTest.DependentServices
         {
             val eventBus: EventBus = SingleThreadedEventBus()
 
@@ -26,9 +26,9 @@ class DeploymentServiceHostTest : DeploymentServiceTest
                 TestClock
             )
 
-            return Pair( deploymentService, eventBus )
+            return DeploymentServiceTest.DependentServices( deploymentService, eventBus )
         }
     }
 
-    override fun createService(): DeploymentService = DeploymentServiceHostTest.createService().first
+    override fun createService(): DeploymentServiceTest.DependentServices = DeploymentServiceHostTest.createService()
 }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/HostsIntegrationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/HostsIntegrationTest.kt
@@ -134,6 +134,22 @@ class HostsIntegrationTest
     }
 
     @Test
+    fun deviceDeployed_second_time_after_reregistration_succeeds() = runTest {
+        // Create a device deployment and unregister the device after.
+        val protocol = createSinglePrimaryDeviceProtocol()
+        val deploymentId = createSinglePrimaryDeviceDeployment( protocol )
+        val primaryDevice = protocol.primaryDevices.single()
+        deploymentService.unregisterDevice( deploymentId, primaryDevice.roleName )
+
+        // Redeploy device.
+        deploymentService.registerDevice( deploymentId, primaryDevice.roleName, primaryDevice.createRegistration() )
+        val deviceDeployment = deploymentService.getDeviceDeploymentFor( deploymentId, primaryDevice.roleName )
+        val deploymentStatus =
+            deploymentService.deviceDeployed( deploymentId, primaryDevice.roleName, deviceDeployment.lastUpdatedOn )
+        assertTrue( deploymentStatus is StudyDeploymentStatus.Running )
+    }
+
+    @Test
     fun removing_deployment_removes_participant_group_and_data_streams() = runTest {
         var deploymentRemoved: DeploymentService.Event.StudyDeploymentRemoved? = null
         eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentRemoved::class, this )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/HostsIntegrationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/HostsIntegrationTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.deployments.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.data.SensorData
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.application.services.createApplicationServiceAdapter
 import dk.cachet.carp.common.application.tasks.Measure
@@ -19,6 +20,7 @@ import dk.cachet.carp.data.application.MutableDataStreamSequence
 import dk.cachet.carp.data.application.SyncPoint
 import dk.cachet.carp.data.infrastructure.InMemoryDataStreamService
 import dk.cachet.carp.data.infrastructure.dataStreamId
+import dk.cachet.carp.data.infrastructure.getDataType
 import dk.cachet.carp.data.infrastructure.measurement
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
@@ -28,6 +30,7 @@ import dk.cachet.carp.deployments.domain.users.ParticipantGroupService
 import dk.cachet.carp.deployments.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployments.infrastructure.InMemoryDeploymentRepository
 import dk.cachet.carp.deployments.infrastructure.InMemoryParticipationRepository
+import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.start
 import dk.cachet.carp.protocols.infrastructure.test.createComplexProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
@@ -118,6 +121,19 @@ class HostsIntegrationTest
     }
 
     @Test
+    fun deviceDeployed_opens_data_streams() = runTest {
+        // Create a device deployment for a protocol with a known data stream.
+        val protocol = createSinglePrimaryDeviceProtocol()
+        addPrimaryDeviceDataStream<StubDataPoint>( protocol )
+        val deploymentId = createSinglePrimaryDeviceDeployment( protocol )
+
+        val primaryDevice = protocol.primaryDevices.single()
+        val dataStreamId = dataStreamId<StubDataPoint>( deploymentId, primaryDevice.roleName )
+        val stream = dataStreamService.getDataStream( dataStreamId, 0 )
+        assertTrue( stream.isEmpty() )
+    }
+
+    @Test
     fun removing_deployment_removes_participant_group_and_data_streams() = runTest {
         var deploymentRemoved: DeploymentService.Event.StudyDeploymentRemoved? = null
         eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentRemoved::class, this )
@@ -126,29 +142,47 @@ class HostsIntegrationTest
         }
         eventBus.activateHandlers( this )
 
-        // Create a protocol which when deployed has one `STUB_DATA_TYPE` data stream.
-        val primaryDevice = StubPrimaryDeviceConfiguration()
-        val deviceRoleName = primaryDevice.roleName
-        val protocol = createEmptyProtocol()
-        protocol.addPrimaryDevice( primaryDevice )
-        val task = StubTaskConfiguration( "Task", listOf( Measure.DataStream( STUB_DATA_POINT_TYPE ) ) )
-        val atStartOfStudy = protocol.addTrigger( primaryDevice.atStartOfStudy() )
-        protocol.addTaskControl( atStartOfStudy.start( task, primaryDevice ) )
-
-        // Create deployment and complete device deployment so that data streams are opened.
-        val invitation = createParticipantInvitation()
-        val deploymentId = UUID.randomUUID()
-        deploymentService.createStudyDeployment( deploymentId, protocol.getSnapshot(), listOf( invitation ) )
-        deploymentService.registerDevice( deploymentId, deviceRoleName, primaryDevice.createRegistration() )
-        val deviceDeployment = deploymentService.getDeviceDeploymentFor( deploymentId, primaryDevice.roleName )
-        deploymentService.deviceDeployed( deploymentId, deviceRoleName, deviceDeployment.lastUpdatedOn )
+        // Create a device deployment for a protocol with a known data stream.
+        val protocol = createSinglePrimaryDeviceProtocol()
+        addPrimaryDeviceDataStream<StubDataPoint>( protocol )
+        val deploymentId = createSinglePrimaryDeviceDeployment( protocol )
 
         deploymentService.removeStudyDeployments( setOf( deploymentId ) )
 
         assertEquals( deploymentId, deploymentRemoved?.studyDeploymentId )
+        val primaryDevice = protocol.primaryDevices.single()
         assertFailsWith<IllegalArgumentException> { participationService.getParticipantData( deploymentId ) }
-        val dataStreamId = dataStreamId<StubDataPoint>( deploymentId, deviceRoleName )
+        val dataStreamId = dataStreamId<StubDataPoint>( deploymentId, primaryDevice.roleName )
         assertFailsWith<IllegalArgumentException> { dataStreamService.getDataStream( dataStreamId, 0 ) }
+    }
+
+    /**
+     * Creates a deployment using [deploymentService] for a [protocol] that only contains a single primary device,
+     * and registers and deploys the primary devices.
+     */
+    private suspend fun createSinglePrimaryDeviceDeployment( protocol: StudyProtocol ): UUID
+    {
+        val deploymentId = UUID.randomUUID()
+        val invitation = createParticipantInvitation()
+        deploymentService.createStudyDeployment( deploymentId, protocol.getSnapshot(), listOf( invitation ) )
+        val primaryDevice = protocol.primaryDevices.single()
+        deploymentService.registerDevice( deploymentId, primaryDevice.roleName, primaryDevice.createRegistration() )
+        val deviceDeployment = deploymentService.getDeviceDeploymentFor( deploymentId, primaryDevice.roleName )
+        deploymentService.deviceDeployed( deploymentId, primaryDevice.roleName, deviceDeployment.lastUpdatedOn )
+
+        return deploymentId
+    }
+
+    /**
+     * Update the protocol to measure [TData] at the start of the study on the primary device.
+     */
+    private inline fun <reified TData : SensorData> addPrimaryDeviceDataStream( protocol: StudyProtocol )
+    {
+        val dataType = getDataType( TData::class )
+        val primaryDevice = protocol.primaryDevices.single()
+        val task = StubTaskConfiguration( "Task", listOf( Measure.DataStream( dataType ) ) )
+        val atStartOfStudy = protocol.addTrigger( primaryDevice.atStartOfStudy() )
+        protocol.addTaskControl( atStartOfStudy.start( task, primaryDevice ) )
     }
 
     @Test

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHostTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHostTest.kt
@@ -19,7 +19,7 @@ class ParticipationServiceHostTest : ParticipationServiceTest
 {
     companion object
     {
-        fun createService(): ParticipationServiceTest.DependentServices
+        fun createSUT(): ParticipationServiceTest.SUT
         {
             val eventBus: EventBus = SingleThreadedEventBus()
 
@@ -38,7 +38,7 @@ class ParticipationServiceHostTest : ParticipationServiceTest
                 eventBus.createApplicationServiceAdapter( ParticipationService::class )
             )
 
-            return ParticipationServiceTest.DependentServices(
+            return ParticipationServiceTest.SUT(
                 participationService,
                 deploymentService,
                 accountService,
@@ -47,6 +47,5 @@ class ParticipationServiceHostTest : ParticipationServiceTest
         }
     }
 
-    override fun createService(): ParticipationServiceTest.DependentServices =
-        ParticipationServiceHostTest.createService()
+    override fun createSUT(): ParticipationServiceTest.SUT = ParticipationServiceHostTest.createSUT()
 }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceTest.kt
@@ -35,7 +35,10 @@ interface ParticipationServiceTest
     }
 
 
-    data class DependentServices(
+    /**
+     * System under test: the [participationService] and all dependencies to be used in tests.
+     */
+    data class SUT(
         val participationService: ParticipationService,
         val deploymentService: DeploymentService,
         val accountService: AccountService,
@@ -43,14 +46,14 @@ interface ParticipationServiceTest
     )
 
     /**
-     * Create a deployment service and account service it depends on to be used in the tests.
+     * Create the system under test (SUT): the [ParticipationService] and all dependencies to be used in tests.
      */
-    fun createService(): DependentServices
+    fun createSUT(): SUT
 
 
     @Test
     fun getActiveParticipationInvitations_succeeds() = runTest {
-        val (participationService, deploymentService, accountService) = createService()
+        val (participationService, deploymentService, accountService) = createSUT()
         val protocol = createSinglePrimaryDeviceProtocol()
         val identity = AccountIdentity.fromEmailAddress( "test@test.com" )
         val invitation = StudyInvitation( "Test study", "description", "Custom data" )
@@ -75,7 +78,7 @@ interface ParticipationServiceTest
 
     @Test
     fun getParticipantData_initially_returns_null_for_all_expected_data() = runTest {
-        val (participationService, deploymentService, _) = createService()
+        val (participationService, deploymentService, _) = createSUT()
 
         // Create protocol with one common custom attribute and 'sex' assigned to two participant roles.
         val protocol = createSinglePrimaryDeviceProtocol( deviceRoleName )
@@ -109,14 +112,14 @@ interface ParticipationServiceTest
 
     @Test
     fun getParticipantData_fails_for_unknown_deploymentId() = runTest {
-        val (participationService, _, _) = createService()
+        val (participationService, _, _) = createSUT()
 
         assertFailsWith<IllegalArgumentException> { participationService.getParticipantData( unknownId ) }
     }
 
     @Test
     fun getParticipantDataList_succeeds() = runTest {
-        val (participationService, deploymentService, _) = createService()
+        val (participationService, deploymentService, _) = createSUT()
         val protocol = createSinglePrimaryDeviceProtocol( deviceRoleName )
         val protocolSnapshot = protocol.getSnapshot()
         val invitation1 = createParticipantInvitation()
@@ -133,7 +136,7 @@ interface ParticipationServiceTest
 
     @Test
     fun getParticipantDataList_fails_for_unknown_deploymentId() = runTest {
-        val (participationService, _, _) = createService()
+        val (participationService, _, _) = createSUT()
 
         val deploymentIds = setOf( unknownId )
         assertFailsWith<IllegalArgumentException> { participationService.getParticipantDataList( deploymentIds ) }
@@ -141,7 +144,7 @@ interface ParticipationServiceTest
 
     @Test
     fun setParticipantData_assigned_to_all_roles_succeeds() = runTest {
-        val (participationService, deploymentService, _) = createService()
+        val (participationService, deploymentService, _) = createSUT()
 
         // Create protocol without roles with expected 'sex' participant data.
         val protocol = createSinglePrimaryDeviceProtocol( deviceRoleName )
@@ -163,7 +166,7 @@ interface ParticipationServiceTest
 
     @Test
     fun setParticipantData_assigned_to_role_succeeds() = runTest {
-        val (participationService, deploymentService, _) = createService()
+        val (participationService, deploymentService, _) = createSUT()
 
         // Create protocol with expected 'sex' participant data for a single participant role.
         val protocol = createSinglePrimaryDeviceProtocol( deviceRoleName )
@@ -191,7 +194,7 @@ interface ParticipationServiceTest
 
     @Test
     fun setParticipantData_fails_for_unknown_deploymentId() = runTest {
-        val (participationService, _, _) = createService()
+        val (participationService, _, _) = createSUT()
 
         val toSet = mapOf( CarpInputDataTypes.SEX to Sex.Male )
         assertFailsWith<IllegalArgumentException>
@@ -202,7 +205,7 @@ interface ParticipationServiceTest
 
     @Test
     fun setParticipantData_fails_for_unexpected_input_for_protocol() = runTest {
-        val (participationService, deploymentService, _) = createService()
+        val (participationService, deploymentService, _) = createSUT()
         val studyDeploymentId = addTestDeployment( deploymentService )
 
         val toSet = mapOf( CarpInputDataTypes.SEX to Sex.Male )
@@ -214,7 +217,7 @@ interface ParticipationServiceTest
 
     @Test
     fun setParticipantData_fails_for_invalid_data() = runTest {
-        val (participationService, deploymentService, _) = createService()
+        val (participationService, deploymentService, _) = createSUT()
 
         // Create protocol with expected 'sex' participant data.
         val protocol = createSinglePrimaryDeviceProtocol( deviceRoleName )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequestsTest.kt
@@ -37,5 +37,5 @@ class DeploymentServiceRequestsTest : ApplicationServiceRequestsTest<DeploymentS
     override fun createServiceLoggingProxy(): ApplicationServiceLoggingProxy<DeploymentService, DeploymentService.Event> =
         DeploymentServiceHostTest
             .createService()
-            .let { DeploymentServiceLoggingProxy( it.first, it.second ) }
+            .let { DeploymentServiceLoggingProxy( it.deploymentService, it.eventBus ) }
 }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequestsTest.kt
@@ -36,6 +36,6 @@ class DeploymentServiceRequestsTest : ApplicationServiceRequestsTest<DeploymentS
 
     override fun createServiceLoggingProxy(): ApplicationServiceLoggingProxy<DeploymentService, DeploymentService.Event> =
         DeploymentServiceHostTest
-            .createService()
+            .createSUT()
             .let { DeploymentServiceLoggingProxy( it.deploymentService, it.eventBus ) }
 }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceRequestsTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceRequestsTest.kt
@@ -33,6 +33,6 @@ class ParticipationServiceRequestsTest : ApplicationServiceRequestsTest<Particip
 
     override fun createServiceLoggingProxy(): ApplicationServiceLoggingProxy<ParticipationService, ParticipationService.Event> =
         ParticipationServiceHostTest
-            .createService()
+            .createSUT()
             .let { ParticipationServiceLoggingProxy( it.participationService, it.eventBus ) }
 }

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.1/DeploymentServiceTest/getDeviceDeploymentFor_during_device_reregistrations.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.1/DeploymentServiceTest/getDeviceDeploymentFor_during_device_reregistrations.json
@@ -1,0 +1,377 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.1",
+            "id": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "protocol": {
+                "id": "f77e5264-c51c-4c43-b90a-f66d5ea3737f",
+                "createdOn": "2022-10-14T11:10:07.313750200Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Test device"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "bdd1904a-5066-44be-81e3-3f54c9821df3",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "Test"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "protocol": {
+                    "id": "f77e5264-c51c-4c43-b90a-f66d5ea3737f",
+                    "createdOn": "2022-10-14T11:10:07.313750200Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Test device"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "bdd1904a-5066-44be-81e3-3f54c9821df3",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "Test"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Test device"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Test device"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Test device"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "bdd1904a-5066-44be-81e3-3f54c9821df3",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Test device"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceRoleName": "Test device",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2022-10-14T11:10:07.314663400Z",
+                "deviceDisplayName": null,
+                "deviceId": "ea06ee55-c6fe-4f27-b583-353bee428bd0"
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Test device"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "registrationCreatedOn": "2022-10-14T11:10:07.314663400Z",
+                    "deviceDisplayName": null,
+                    "deviceId": "ea06ee55-c6fe-4f27-b583-353bee428bd0"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Test device"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "bdd1904a-5066-44be-81e3-3f54c9821df3",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Test device"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "primaryDeviceRoleName": "Test device"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "deviceConfiguration": {
+                "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                "isPrimaryDevice": true,
+                "roleName": "Test device"
+            },
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2022-10-14T11:10:07.314663400Z",
+                "deviceDisplayName": null,
+                "deviceId": "ea06ee55-c6fe-4f27-b583-353bee428bd0"
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceRoleName": "Test device"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Test device"
+                },
+                "registration": null
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Test device"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Test device"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Test device"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "bdd1904a-5066-44be-81e3-3f54c9821df3",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Test device"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "primaryDeviceRoleName": "Test device"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "exceptionType": "IllegalArgumentException"
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceRoleName": "Test device",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2022-10-14T11:10:07.315686800Z",
+                "deviceDisplayName": null,
+                "deviceId": "96a6d873-157a-4445-89d0-9980890931ba"
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Test device"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "registrationCreatedOn": "2022-10-14T11:10:07.315686800Z",
+                    "deviceDisplayName": null,
+                    "deviceId": "96a6d873-157a-4445-89d0-9980890931ba"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Test device"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "bdd1904a-5066-44be-81e3-3f54c9821df3",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Test device"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "bdbb4372-f17d-48a9-b271-5dd59fa62639",
+            "primaryDeviceRoleName": "Test device"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "deviceConfiguration": {
+                "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                "isPrimaryDevice": true,
+                "roleName": "Test device"
+            },
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2022-10-14T11:10:07.315686800Z",
+                "deviceDisplayName": null,
+                "deviceId": "96a6d873-157a-4445-89d0-9980890931ba"
+            }
+        }
+    }
+]

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 class DeploymentServiceBackwardsCompatibilityTest :
     BackwardsCompatibilityTest<DeploymentService>( DeploymentService::class )
 {
-    override fun createService() = DeploymentServiceHostTest.createService()
+    override fun createService() = DeploymentServiceHostTest.createSUT()
         .let { Pair( it.deploymentService, it.eventBus ) }
 }
 
@@ -21,6 +21,6 @@ class DeploymentServiceBackwardsCompatibilityTest :
 class ParticipationServiceBackwardsCompatibilityTest :
     BackwardsCompatibilityTest<ParticipationService>( ParticipationService::class )
 {
-    override fun createService() = ParticipationServiceHostTest.createService()
+    override fun createService() = ParticipationServiceHostTest.createSUT()
         .let { Pair( it.participationService, it.eventBus ) }
 }

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -13,6 +13,7 @@ class DeploymentServiceBackwardsCompatibilityTest :
     BackwardsCompatibilityTest<DeploymentService>( DeploymentService::class )
 {
     override fun createService() = DeploymentServiceHostTest.createService()
+        .let { Pair( it.deploymentService, it.eventBus ) }
 }
 
 

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputDeploymentServiceTestRequests.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputDeploymentServiceTestRequests.kt
@@ -11,11 +11,12 @@ class OutputDeploymentServiceTestRequests :
     OutputTestRequests<DeploymentService>( DeploymentService::class ),
     DeploymentServiceTest
 {
-    override fun createService(): DeploymentService
+    override fun createService(): DeploymentServiceTest.DependentServices
     {
         val services = DeploymentServiceHostTest.createService()
+        val service = DeploymentServiceLoggingProxy( services.deploymentService, services.eventBus )
+        loggedService = service
 
-        return DeploymentServiceLoggingProxy( services.first, services.second )
-            .also { loggedService = it }
+        return DeploymentServiceTest.DependentServices( service, services.eventBus )
     }
 }

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputDeploymentServiceTestRequests.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputDeploymentServiceTestRequests.kt
@@ -11,12 +11,12 @@ class OutputDeploymentServiceTestRequests :
     OutputTestRequests<DeploymentService>( DeploymentService::class ),
     DeploymentServiceTest
 {
-    override fun createService(): DeploymentServiceTest.DependentServices
+    override fun createSUT(): DeploymentServiceTest.SUT
     {
-        val services = DeploymentServiceHostTest.createService()
+        val services = DeploymentServiceHostTest.createSUT()
         val service = DeploymentServiceLoggingProxy( services.deploymentService, services.eventBus )
         loggedService = service
 
-        return DeploymentServiceTest.DependentServices( service, services.eventBus )
+        return DeploymentServiceTest.SUT( service, services.eventBus )
     }
 }

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputParticipationServiceTestRequests.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputParticipationServiceTestRequests.kt
@@ -11,13 +11,13 @@ class OutputParticipationServiceTestRequests :
     OutputTestRequests<ParticipationService>( ParticipationService::class ),
     ParticipationServiceTest
 {
-    override fun createService(): ParticipationServiceTest.DependentServices
+    override fun createSUT(): ParticipationServiceTest.SUT
     {
-        val services = ParticipationServiceHostTest.createService()
+        val services = ParticipationServiceHostTest.createSUT()
         val service = ParticipationServiceLoggingProxy( services.participationService, services.eventBus )
         loggedService = service
 
-        return ParticipationServiceTest.DependentServices(
+        return ParticipationServiceTest.SUT(
             service,
             services.deploymentService,
             services.accountService,

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
@@ -19,7 +19,7 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
 {
     companion object
     {
-        fun createService(): RecruitmentServiceTest.DependentServices
+        fun createSUT(): RecruitmentServiceTest.SUT
         {
             val eventBus = SingleThreadedEventBus()
 
@@ -48,9 +48,9 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
                 TestClock
             )
 
-            return RecruitmentServiceTest.DependentServices( recruitmentService, studyService, eventBus )
+            return RecruitmentServiceTest.SUT( recruitmentService, studyService, eventBus )
         }
     }
 
-    override fun createService(): RecruitmentServiceTest.DependentServices = RecruitmentServiceHostTest.createService()
+    override fun createSUT(): RecruitmentServiceTest.SUT = RecruitmentServiceHostTest.createSUT()
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -25,21 +25,24 @@ private val unknownId: UUID = UUID.randomUUID()
  */
 interface RecruitmentServiceTest
 {
-    data class DependentServices(
+    /**
+     * System under test: the [recruitmentService] and all dependencies to be used in tests.
+     */
+    data class SUT(
         val recruitmentService: RecruitmentService,
         val studyService: StudyService,
         val eventBus: EventBus
     )
 
     /**
-     * Create a recruitment service and study service it depends on to be used in the tests.
+     * Create the system under test (SUT): the [RecruitmentService] and all dependencies to be used in tests.
      */
-    fun createService(): DependentServices
+    fun createSUT(): SUT
 
 
     @Test
     fun adding_and_retrieving_participant_succeeds() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val study = studyService.createStudy( UUID.randomUUID(), "Test" )
         val studyId = study.studyId
 
@@ -56,7 +59,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun addParticipant_fails_for_unknown_studyId() = runTest {
-        val (recruitmentService, _) = createService()
+        val (recruitmentService, _) = createSUT()
 
         val email = EmailAddress( "test@test.com" )
         assertFailsWith<IllegalArgumentException> { recruitmentService.addParticipant( unknownId, email ) }
@@ -65,7 +68,7 @@ interface RecruitmentServiceTest
     @Suppress( "ReplaceAssertBooleanWithAssertEquality" )
     @Test
     fun addParticipant_twice_returns_same_participant() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val study = studyService.createStudy( UUID.randomUUID(), "Test" )
         val studyId = study.studyId
 
@@ -77,7 +80,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun getParticipant_fails_for_unknown_id() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val study = studyService.createStudy( UUID.randomUUID(), "Test" )
 
         // Unknown study id.
@@ -89,14 +92,14 @@ interface RecruitmentServiceTest
 
     @Test
     fun getParticipants_fails_for_unknown_studyId() = runTest {
-        val (recruitmentService, _) = createService()
+        val (recruitmentService, _) = createSUT()
 
         assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipants( unknownId ) }
     }
 
     @Test
     fun inviteNewParticipantGroup_succeeds() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
@@ -110,7 +113,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_fails_for_unknown_studyId() = runTest {
-        val (recruitmentService, _) = createService()
+        val (recruitmentService, _) = createSUT()
         val assignParticipant = AssignedParticipantRoles( UUID.randomUUID(), AssignedTo.All )
 
         assertFailsWith<IllegalArgumentException>
@@ -121,7 +124,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_fails_for_empty_group() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
 
         assertFailsWith<IllegalArgumentException> { recruitmentService.inviteNewParticipantGroup( studyId, setOf() ) }
@@ -129,7 +132,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_fails_for_unknown_participants() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
 
         val assignParticipant = AssignedParticipantRoles( unknownId, AssignedTo.All )
@@ -141,7 +144,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_fails_for_unknown_participant_roles() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
@@ -154,7 +157,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_fails_when_not_all_participant_roles_assigned() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, protocol) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
@@ -168,7 +171,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_multiple_times_returns_same_group() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
@@ -181,7 +184,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun inviteNewParticipantGroup_for_previously_stopped_group_returns_new_group() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
@@ -195,7 +198,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun getParticipantGroupStatusList_returns_multiple_deployments() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
 
         val p1 = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
@@ -214,14 +217,14 @@ interface RecruitmentServiceTest
 
     @Test
     fun getParticipantGroupStatusLists_fails_for_unknown_studyId() = runTest {
-        val (recruitmentService, _) = createService()
+        val (recruitmentService, _) = createSUT()
 
         assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipantGroupStatusList( unknownId ) }
     }
 
     @Test
     fun stopParticipantGroup_succeeds() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
@@ -233,7 +236,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun stopParticipantGroup_fails_with_unknown_studyId() = runTest {
-        val (recruitmentService, _) = createService()
+        val (recruitmentService, _) = createSUT()
 
         assertFailsWith<IllegalArgumentException>
         {
@@ -243,7 +246,7 @@ interface RecruitmentServiceTest
 
     @Test
     fun stopParticipantGroup_fails_with_unknown_groupId() = runTest {
-        val (recruitmentService, studyService) = createService()
+        val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
 
         assertFailsWith<IllegalArgumentException> { recruitmentService.stopParticipantGroup( studyId, unknownId ) }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequestsTest.kt
@@ -33,6 +33,6 @@ class RecruitmentServiceRequestsTest : ApplicationServiceRequestsTest<Recruitmen
 
     override fun createServiceLoggingProxy(): ApplicationServiceLoggingProxy<RecruitmentService, RecruitmentService.Event> =
         RecruitmentServiceHostTest
-            .createService()
+            .createSUT()
             .let { RecruitmentServiceLoggingProxy( it.recruitmentService, it.eventBus ) }
 }

--- a/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -20,6 +20,6 @@ class StudyServiceBackwardsCompatibilityTest :
 class RecruitmentServiceBackwardsCompatibilityTest :
     BackwardsCompatibilityTest<RecruitmentService>( RecruitmentService::class )
 {
-    override fun createService() = RecruitmentServiceHostTest.createService()
+    override fun createService() = RecruitmentServiceHostTest.createSUT()
         .let { Pair( it.recruitmentService, it.eventBus ) }
 }

--- a/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputRecruitmentServiceTestRequests.kt
+++ b/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputRecruitmentServiceTestRequests.kt
@@ -11,13 +11,13 @@ class OutputRecruitmentServiceTestRequests :
     OutputTestRequests<RecruitmentService>( RecruitmentService::class ),
     RecruitmentServiceTest
 {
-    override fun createService(): RecruitmentServiceTest.DependentServices
+    override fun createSUT(): RecruitmentServiceTest.SUT
     {
-        val services = RecruitmentServiceHostTest.createService()
+        val services = RecruitmentServiceHostTest.createSUT()
         val service = RecruitmentServiceLoggingProxy( services.recruitmentService, services.eventBus )
         loggedService = service
 
-        return RecruitmentServiceTest.DependentServices(
+        return RecruitmentServiceTest.SUT(
             service,
             services.studyService,
             services.eventBus


### PR DESCRIPTION
Redeploying devices would fail since upon device deployment `DataStreamService.openDataStreams` is called, which on a second call would throw an exception indicating data streams were already open (Closes #383).

This is now fixed simply by swallowing the exception, since the requested data streams are known not to have changed.

However, this can probably be improved by changing the endpoints behavior, but this would be a breaking API change, thus [I scheduled this for 2.0 instead](https://github.com/imotions/carp.core-kotlin/issues/414).

While looking into this, I added additional tests covering `getDeviceDeploymentFor`, one of which is part of the backwards compatibility tests and thus got added to test resources.