### PR TITLE
Upgrade to Kotlin 1.8.0-RC2 and serialization 1.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ task copyTestJsSources(type: Copy, dependsOn: setupTsProject) {
             if (path == ".visited") return // We don't need this file.
 
             // Remove intermediate version directory: e.g. "kotlin/1.5.10/kotlin.js"
-            it.path = path.replaceFirst(/\d+\.\d+.\d+\//, "")
+            it.path = path.replaceFirst(/\d+\.\d+.\d+(-.+)?\//, "")
         }
     }
     into "./$typescriptFolder/node_modules"

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ buildscript {
             bigJs:'6.1.1',
 
             // DevOps versions.
-            detektPlugin:'1.20.0-RC2',
-            detektVerifyImplementation:'1.2.2',
+            detektPlugin:'1.22.0',
+            detektVerifyImplementation:'1.2.4',
             nexusPublishPlugin:'1.1.0',
             apacheCommons:'2.11.0'
         ]

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.6.10',
-            serialization:'1.3.2',
+            kotlin:'1.8.0-RC2',
+            serialization:'1.4.1',
             coroutines:'1.6.0',
             datetime:'0.3.2',
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,17 @@ buildscript {
             // Kotlin multiplatform versions.
             kotlin:'1.8.0-RC2',
             serialization:'1.4.1',
-            coroutines:'1.6.0',
-            datetime:'0.3.2',
+            coroutines:'1.6.4',
+            datetime:'0.4.0',
 
             // JVM versions.
             jvmTarget:'1.8',
-            dokkaPlugin:'1.6.10',
+            dokkaPlugin:'1.7.20',
             reflections:'0.10.2',
 
             // JS versions.
-            nodePlugin:'3.2.1',
-            bigJs:'6.1.1',
+            nodePlugin:'3.5.0',
+            bigJs:'6.2.1',
 
             // DevOps versions.
             detektPlugin:'1.22.0',

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/application/study/StudyStatus.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/application/study/StudyStatus.kt
@@ -60,7 +60,8 @@ sealed class StudyStatus
                     is DeviceDeploymentStatus.NotDeployed ->
                         if ( deploymentInformation == null || deviceStatus is DeviceDeploymentStatus.NeedsRedeployment )
                         {
-                            if ( deviceStatus.canObtainDeviceDeployment ) AwaitingDeviceDeployment( id, deployingDevices )
+                            val readyToDeploy = deviceStatus.canObtainDeviceDeployment
+                            if ( readyToDeploy ) AwaitingDeviceDeployment( id, deployingDevices )
                             else AwaitingOtherDeviceRegistrations( id, deployingDevices )
                         }
                         else

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/SmartphoneClient.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/SmartphoneClient.kt
@@ -34,5 +34,6 @@ ClientManager<Smartphone, SmartphoneDeviceRegistration, SmartphoneDeviceRegistra
     dataCollectorFactory
 )
 {
-    override fun createDeviceRegistrationBuilder(): SmartphoneDeviceRegistrationBuilder = SmartphoneDeviceRegistrationBuilder()
+    override fun createDeviceRegistrationBuilder(): SmartphoneDeviceRegistrationBuilder =
+        SmartphoneDeviceRegistrationBuilder()
 }

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/data/DataListener.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/data/DataListener.kt
@@ -5,6 +5,8 @@ import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.DeviceRegistration
 import dk.cachet.carp.common.application.devices.DeviceType
 
+typealias DataCollectorMap = MutableMap<DeviceRegistration, AnyConnectedDeviceDataCollector>
+
 
 /**
  * Allows subscribing to [Data] (e.g., sensors, surveys) of requested [DataType]s on a primary device and connected devices
@@ -12,7 +14,7 @@ import dk.cachet.carp.common.application.devices.DeviceType
  */
 class DataListener( private val dataCollectorFactory: DeviceDataCollectorFactory )
 {
-    private val connectedDataCollectors: MutableMap<DeviceType, MutableMap<DeviceRegistration, AnyConnectedDeviceDataCollector>> = mutableMapOf()
+    private val connectedDataCollectors: MutableMap<DeviceType, DataCollectorMap> = mutableMapOf()
 
 
     /**
@@ -40,7 +42,10 @@ class DataListener( private val dataCollectorFactory: DeviceDataCollectorFactory
      *
      * @return The [ConnectedDeviceDataCollector], or null in case it could not be created.
      */
-    fun tryGetConnectedDataCollector( connectedDeviceType: DeviceType, registration: DeviceRegistration ): AnyConnectedDeviceDataCollector?
+    fun tryGetConnectedDataCollector(
+        connectedDeviceType: DeviceType,
+        registration: DeviceRegistration
+    ): AnyConnectedDeviceDataCollector?
     {
         return try
         {

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/Study.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/Study.kt
@@ -131,7 +131,9 @@ class Study(
             if ( device.isConnectedDevice )
             {
                 dataListener.tryGetConnectedDataCollector( deviceType, registration )
-                    ?: throw UnsupportedOperationException( "Connecting to device of type \"$deviceType\" is not supported on this client." )
+                    ?: throw UnsupportedOperationException(
+                        "Connecting to device of type \"$deviceType\" is not supported on this client."
+                    )
             }
 
             val dataTypes = device.tasks

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/Study.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/Study.kt
@@ -115,7 +115,7 @@ class Study(
     fun validateDeviceDeployment( dataListener: DataListener )
     {
         val deployment = checkNotNull( deploymentInformation )
-        val remainingDevicesToRegister = deploymentStatus?.getRemainingDevicesToRegister() ?: emptySet()
+        val remainingDevicesToRegister = deploymentStatus?.getRemainingDevicesToRegister().orEmpty()
 
         // All devices need to be registered before deployment can be validated.
         check( remainingDevicesToRegister.isEmpty() )

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/StudyDeploymentProxy.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/StudyDeploymentProxy.kt
@@ -71,7 +71,8 @@ class StudyDeploymentProxy(
             study.deploymentStatusReceived( deployedStatus )
         }
         // Handle race conditions with competing clients modifying device registrations, invalidating this deployment.
-        catch ( ignore: IllegalArgumentException ) { } // TODO: When deployment is out of date, maybe also use `IllegalStateException` for easier handling here.
+        // TODO: When deployment is out of date, maybe also use `IllegalStateException` for easier handling here.
+        catch ( ignore: IllegalArgumentException ) { }
         catch ( ignore: IllegalStateException ) { }
     }
 

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/StudySnapshot.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/domain/study/StudySnapshot.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.deployments.application.PrimaryDeviceDeployment
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/infrastructure/InMemoryClientRepository.kt
+++ b/carp.clients.core/src/commonMain/kotlin/dk/cachet/carp/clients/infrastructure/InMemoryClientRepository.kt
@@ -73,7 +73,8 @@ class InMemoryClientRepository : ClientRepository
     override suspend fun updateStudy( study: Study )
     {
         val storedStudy = findStudySnapshot( study )
-        requireNotNull( storedStudy ) { "The repository does not contain an existing study matching the one to update." }
+        requireNotNull( storedStudy )
+            { "The repository does not contain an existing study matching the one to update." }
 
         studies.remove( storedStudy )
         studies.add( study.getSnapshot() )

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/ClientCodeSamples.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/ClientCodeSamples.kt
@@ -124,7 +124,8 @@ class ClientCodeSamples
      * A stub [DataListener] which supports the expected data types in [createExampleProtocol].
      */
     private fun createDataCollectorFactory() = createDataCollectorFactory(
-        CarpDataTypes.GEOLOCATION, CarpDataTypes.STEP_COUNT
+        CarpDataTypes.GEOLOCATION,
+        CarpDataTypes.STEP_COUNT
     )
 
     private val accountService = InMemoryAccountService()

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/CreateTestObjects.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/CreateTestObjects.kt
@@ -78,7 +78,11 @@ suspend fun createStudyDeployment( protocol: StudyProtocol ): Pair<DeploymentSer
         eventBus.createApplicationServiceAdapter( DeploymentService::class )
     )
     val invitation = createParticipantInvitation()
-    val status = deploymentService.createStudyDeployment( UUID.randomUUID(), protocol.getSnapshot(), listOf( invitation ) )
+    val status = deploymentService.createStudyDeployment(
+        UUID.randomUUID(),
+        protocol.getSnapshot(),
+        listOf( invitation )
+    )
     return Pair( deploymentService, status )
 }
 

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/ClientRepositoryTest.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/ClientRepositoryTest.kt
@@ -91,7 +91,7 @@ interface ClientRepositoryTest
         // Make some changes and update.
         val primaryDevice = StubPrimaryDeviceConfiguration( deviceRoleName )
         val registration = primaryDevice.createRegistration()
-        val primaryDeviceDeployment = PrimaryDeviceDeployment( StubPrimaryDeviceConfiguration( deviceRoleName ), registration )
+        val primaryDeviceDeployment = PrimaryDeviceDeployment( primaryDevice, registration )
         study.deploymentStatusReceived(
             StudyDeploymentStatus.DeployingDevices(
                 Clock.System.now(),

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/data/DataListenerTest.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/data/DataListenerTest.kt
@@ -45,11 +45,12 @@ class DataListenerTest
     fun unsupported_connected_devices()
     {
         val factory = StubConnectedDeviceDataCollectorFactory( emptySet(), emptyMap() ) // Nothing is supported.
-        val listener = DataListener( factory )
-
         val unsupportedDeviceType = StubDeviceConfiguration::class
         val registration = StubDeviceConfiguration().createRegistration()
-        assertNull( listener.tryGetConnectedDataCollector( unsupportedDeviceType, registration ) )
-        assertFalse( listener.supportsDataOnConnectedDevice( STUB_DATA_POINT_TYPE, unsupportedDeviceType, registration ) )
+
+        DataListener( factory ).apply {
+            assertNull( tryGetConnectedDataCollector( unsupportedDeviceType, registration ) )
+            assertFalse( supportsDataOnConnectedDevice( STUB_DATA_POINT_TYPE, unsupportedDeviceType, registration ) )
+        }
     }
 }

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/data/StubDeviceDataCollectorFactory.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/data/StubDeviceDataCollectorFactory.kt
@@ -19,5 +19,6 @@ class StubDeviceDataCollectorFactory(
     override fun createConnectedDataCollector(
         deviceType: DeviceType,
         deviceRegistration: DeviceRegistration
-    ): AnyConnectedDeviceDataCollector = StubConnectedDeviceDataCollector( connectedSupportedDataTypes, deviceRegistration )
+    ): AnyConnectedDeviceDataCollector =
+        StubConnectedDeviceDataCollector( connectedSupportedDataTypes, deviceRegistration )
 }

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/study/StudyDeploymentProxyTest.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/study/StudyDeploymentProxyTest.kt
@@ -220,10 +220,12 @@ class StudyDeploymentProxyTest
     fun tryDeployment_succeeds_when_data_types_of_protocol_measures_are_supported() = runTest {
         // Create protocol that measures on smartphone and one connected device.
         val protocol = createSmartphoneWithConnectedDeviceStudy()
-        val primaryTask = StubTaskConfiguration( "Primary measure", listOf( Measure.DataStream( STUB_DATA_POINT_TYPE ) ) )
+        val primaryTask =
+            StubTaskConfiguration( "Primary measure", listOf( Measure.DataStream( STUB_DATA_POINT_TYPE ) ) )
         protocol.addTaskControl( smartphone.atStartOfStudy().start( primaryTask, smartphone ) )
         val connectedDataType = DataType( "custom", "type" )
-        val connectedTask = StubTaskConfiguration( "Connected measure", listOf( Measure.DataStream( connectedDataType ) ) )
+        val connectedTask =
+            StubTaskConfiguration( "Connected measure", listOf( Measure.DataStream( connectedDataType ) ) )
         protocol.addTaskControl( smartphone.atStartOfStudy().start( connectedTask, connectedDevice ) )
 
         // Create a data listener which supports the requested devices and types in the protocol

--- a/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/ApplicationServiceRequestsTest.kt
+++ b/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/ApplicationServiceRequestsTest.kt
@@ -6,11 +6,9 @@ import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.elementDescriptors
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.json.*
 import kotlin.test.*
 
 

--- a/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/LoggedJsonRequest.kt
+++ b/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/LoggedJsonRequest.kt
@@ -1,13 +1,8 @@
 package dk.cachet.carp.common.test.infrastructure.versioning
 
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonClassDiscriminator
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 
 
 /**

--- a/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/SubsystemArchitectureTest.kt
+++ b/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/SubsystemArchitectureTest.kt
@@ -4,7 +4,6 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.common.test.infrastructure.SnapshotTest
-import kotlinx.serialization.builtins.serializer
 import org.reflections.Reflections
 import kotlin.jvm.internal.Reflection
 import kotlin.reflect.KClass

--- a/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -10,12 +10,9 @@ import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.*
 import org.apache.commons.io.FileUtils
 import java.io.File
 import kotlin.reflect.KClass

--- a/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -46,7 +46,7 @@ abstract class BackwardsCompatibilityTest<TService : ApplicationService<TService
     fun setup()
     {
         // Get available test versions.
-        val directories = testRequestsFolder.listFiles()?.filter { it.isDirectory } ?: emptyList()
+        val directories = testRequestsFolder.listFiles()?.filter { it.isDirectory }.orEmpty()
         availableTestVersions = directories.map {
             val versionMatch = assertNotNull(
                 Regex( """(\d)\.(\d)""" ).find( it.name ),

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/EmailAddress.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/EmailAddress.kt
@@ -19,4 +19,5 @@ data class EmailAddress( val address: String )
 /**
  * A custom serializer for [EmailAddress].
  */
-object EmailAddressSerializer : KSerializer<EmailAddress> by createCarpStringPrimitiveSerializer( { EmailAddress( it ) } )
+object EmailAddressSerializer : KSerializer<EmailAddress> by
+    createCarpStringPrimitiveSerializer( { EmailAddress( it ) } )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/EmailAddress.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/EmailAddress.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/MACAddress.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/MACAddress.kt
@@ -25,7 +25,10 @@ data class MACAddress(
     init
     {
         require( MACAddressRegex.matches( this.address ) )
-            { "Invalid MAC address string representation: expected six groups of two upper case hexadecimal digits, separated by hyphens (-)." }
+        {
+            "Invalid MAC address string representation: " +
+            "expected six groups of two upper case hexadecimal digits, separated by hyphens (-)."
+        }
     }
 
 
@@ -42,7 +45,11 @@ data class MACAddress(
         fun parse( address: String ): MACAddress
         {
             require( address.split( ':' ).size == GROUPS || address.split( '-' ).size == GROUPS )
-                { "Invalid MAC address string representation: expected six groups of two hexadecimal digits (upper or lower case), separated by hyphens (-) or colons (:)." }
+            {
+                "Invalid MAC address string representation: " +
+                "expected six groups of two hexadecimal digits (upper or lower case), " +
+                "separated by hyphens (-) or colons (:)."
+            }
 
             val recommendedFormatting = address.uppercase().replace( ':', '-' )
             return MACAddress( recommendedFormatting )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/MACAddress.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/MACAddress.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/NamespacedId.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/NamespacedId.kt
@@ -31,9 +31,15 @@ data class NamespacedId(
     init
     {
         require( namespaceRegex.matches( namespace ) )
-            { "Invalid namespace representation: expected lowercase alpha-numeric (underscore included) words delimited by dots." }
+        {
+            "Invalid namespace representation: " +
+            "expected lowercase alpha-numeric (underscore included) words delimited by dots."
+        }
         require( nameRegex.matches( name ) )
-            { "Invalid name representation: expected a single lowercase alpha-numeric (underscore included) word." }
+        {
+            "Invalid name representation: " +
+            "expected a single lowercase alpha-numeric (underscore included) word."
+        }
     }
 
 
@@ -78,4 +84,5 @@ val nameRegex = """^[a-z_0-9]+?$""".toRegex()
 /**
  * A custom serializer for [NamespacedId].
  */
-object NamespacedIdSerializer : KSerializer<NamespacedId> by createCarpStringPrimitiveSerializer( { s -> NamespacedId.fromString( s ) } )
+object NamespacedIdSerializer : KSerializer<NamespacedId> by
+    createCarpStringPrimitiveSerializer( { s -> NamespacedId.fromString( s ) } )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/NamespacedId.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/NamespacedId.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/RecurrenceRule.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/RecurrenceRule.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.DurationSerializer
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.microseconds
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/RecurrenceRule.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/RecurrenceRule.kt
@@ -54,7 +54,8 @@ data class RecurrenceRule(
          */
         fun fromString( rrule: String ): RecurrenceRule
         {
-            require( RecurrenceRuleRegex.matches( rrule ) ) { "Invalid or unsupported RecurrenceRule string representation." }
+            require( RecurrenceRuleRegex.matches( rrule ) )
+                { "Invalid or unsupported RecurrenceRule string representation." }
 
             // Extract parameters.
             val parameters = rrule.substring( "RRULE:".length )
@@ -67,11 +68,14 @@ data class RecurrenceRule(
 
             // Verify parameter correctness.
             val supportedParameters = listOf( "FREQ", "INTERVAL", "UNTIL", "COUNT" )
-            require( parameters.keys.all { it in supportedParameters } ) { "Invalid or unsupported RRULE parameter found." }
-            require( parameters.keys.distinct().count() == parameters.keys.count() ) { "RRULE does not allow repeating the same parameter multiple times." }
+            require( parameters.keys.all { it in supportedParameters } )
+                { "Invalid or unsupported RRULE parameter found." }
+            require( parameters.keys.distinct().count() == parameters.keys.count() )
+                { "RRULE does not allow repeating the same parameter multiple times." }
 
             // Extract frequency.
-            val frequencyString = parameters[ "FREQ" ] ?: throw IllegalArgumentException( "FREQ needs to be specified." )
+            val frequencyString = parameters[ "FREQ" ]
+                ?: throw IllegalArgumentException( "FREQ needs to be specified." )
             val frequency = Frequency.valueOf( frequencyString )
 
             // Extract remaining parameters.
@@ -162,10 +166,12 @@ data class RecurrenceRule(
 /**
  * Regular expression to verify whether the structure of the string representation of a [RecurrenceRule] is valid.
  */
-val RecurrenceRuleRegex = Regex( """RRULE:FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)(;(INTERVAL|UNTIL|COUNT)=\d+)*""" )
+val RecurrenceRuleRegex =
+    Regex( """RRULE:FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)(;(INTERVAL|UNTIL|COUNT)=\d+)*""" )
 
 
 /**
  * A custom serializer for [RecurrenceRule].
  */
-object RecurrenceRuleSerializer : KSerializer<RecurrenceRule> by createCarpStringPrimitiveSerializer( { s -> RecurrenceRule.fromString( s ) } )
+object RecurrenceRuleSerializer : KSerializer<RecurrenceRule> by
+    createCarpStringPrimitiveSerializer( { s -> RecurrenceRule.fromString( s ) } )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/TimeOfDay.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/TimeOfDay.kt
@@ -58,4 +58,5 @@ val TimeOfDayRegex = Regex( """\d\d:\d\d:\d\d""" )
 /**
  * A custom serializer for [TimeOfDay].
  */
-object TimeOfDaySerializer : KSerializer<TimeOfDay> by createCarpStringPrimitiveSerializer( { s -> TimeOfDay.fromString( s ) } )
+object TimeOfDaySerializer : KSerializer<TimeOfDay> by
+    createCarpStringPrimitiveSerializer( { s -> TimeOfDay.fromString( s ) } )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/TimeOfDay.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/TimeOfDay.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -12,40 +12,56 @@ import kotlinx.serialization.Serializable
  * @param stringRepresentation The recommended RFC 4122 notation of UUID. Hexadecimal digits should be lowercase.
  */
 @Serializable( UUIDSerializer::class )
-expect class UUID( stringRepresentation: String )
+class UUID( val stringRepresentation: String )
 {
-    val stringRepresentation: String
+    init
+    {
+        require( UUIDRegex.matches( stringRepresentation ) ) { "Invalid UUID string representation." }
+    }
 
-
-    companion object : UUIDFactory
+    companion object
     {
         /**
          * Parse common [UUID] representations, also allowing upper case hexadecimal digits.
          *
          * TODO: It might be useful to allow even more flexible [uuid] entry (e.g., surrounded by curly braces, etc.).
          */
-        fun parse( uuid: String ): UUID
+        fun parse( uuid: String ): UUID = UUID( uuid.lowercase() )
 
-        override fun randomUUID(): UUID
+        fun randomUUID(): UUID = DefaultUUIDFactory.randomUUID()
     }
 
 
-    override fun toString(): String
-}
+    override fun equals( other: Any? ): Boolean
+    {
+        if ( this === other ) return true
+        if ( other !is UUID ) return false
 
-interface UUIDFactory
-{
-    fun randomUUID(): UUID
-}
+        return stringRepresentation == other.stringRepresentation
+    }
 
+    override fun hashCode(): Int = stringRepresentation.hashCode()
+
+    override fun toString(): String = stringRepresentation
+}
 
 /**
  * Regular expression to match [UUID] using the recommended RFC 4122 notation. Hexadecimal digits should be lowercase.
  */
 val UUIDRegex = Regex( "([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})" )
 
-
 /**
  * A custom serializer for [UUID].
  */
 object UUIDSerializer : KSerializer<UUID> by createCarpStringPrimitiveSerializer( { UUID( it ) } )
+
+
+expect object DefaultUUIDFactory : UUIDFactory
+{
+    override fun randomUUID(): UUID
+}
+
+interface UUIDFactory
+{
+    fun randomUUID(): UUID
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/Acceleration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/Acceleration.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 /**
  * Holds rate of change in velocity, including gravity, along perpendicular [x], [y], and [z] axes in meters per second squared (m/s^2).

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/AngularVelocity.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/AngularVelocity.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/CarpDataTypes.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/CarpDataTypes.kt
@@ -19,83 +19,139 @@ object CarpDataTypes : DataTypeMetaDataMap()
     /**
      * Geographic location data, representing latitude and longitude within the World Geodetic System 1984.
      */
-    val GEOLOCATION = add( GEOLOCATION_TYPE_NAME, "Geolocation", DataTimeType.POINT )
+    val GEOLOCATION = add(
+        GEOLOCATION_TYPE_NAME,
+        "Geolocation",
+        DataTimeType.POINT
+    )
 
     internal const val STEP_COUNT_TYPE_NAME = "$CARP_NAMESPACE.stepcount"
     /**
      * Step count data, representing the number of steps a participant has taken in a specified time interval.
      */
-    val STEP_COUNT = add( STEP_COUNT_TYPE_NAME, "Step count", DataTimeType.TIME_SPAN )
+    val STEP_COUNT = add(
+        STEP_COUNT_TYPE_NAME,
+        "Step count",
+        DataTimeType.TIME_SPAN
+    )
 
     internal const val ECG_TYPE_NAME = "$CARP_NAMESPACE.ecg"
     /**
      * Electrocardiography (ECG) data, representing electrical activity of the heart for a single lead.
      */
-    val ECG = add( ECG_TYPE_NAME, "Electrocardiography (ECG)", DataTimeType.POINT )
+    val ECG = add(
+        ECG_TYPE_NAME,
+        "Electrocardiography (ECG)",
+        DataTimeType.POINT
+    )
 
     internal const val PPG_TYPE_NAME = "$CARP_NAMESPACE.ppg"
     /**
      * Photoplethysmography (PPG) data, representing blood volume changes measured at the skin's surface.
      */
-    val PPG = add( PPG_TYPE_NAME, "Photoplethysmography (PPG)", DataTimeType.POINT )
+    val PPG = add(
+        PPG_TYPE_NAME,
+        "Photoplethysmography (PPG)",
+        DataTimeType.POINT
+    )
 
     internal const val HEART_RATE_TYPE_NAME = "$CARP_NAMESPACE.heartrate"
     /**
      * Represents the number of heart contractions (beats) per minute.
      */
-    val HEART_RATE = add( HEART_RATE_TYPE_NAME, "Heart rate", DataTimeType.POINT )
+    val HEART_RATE = add(
+        HEART_RATE_TYPE_NAME,
+        "Heart rate",
+        DataTimeType.POINT
+    )
 
     internal const val INTERBEAT_INTERVAL_TYPE_NAME = "$CARP_NAMESPACE.interbeatinterval"
     /**
      * The time interval between two consecutive heartbeats.
      */
-    val INTERBEAT_INTERVAL = add( INTERBEAT_INTERVAL_TYPE_NAME, "Interbeat interval", DataTimeType.TIME_SPAN )
+    val INTERBEAT_INTERVAL = add(
+        INTERBEAT_INTERVAL_TYPE_NAME,
+        "Interbeat interval",
+        DataTimeType.TIME_SPAN
+    )
 
     internal const val SENSOR_SKIN_CONTACT_TYPE_NAME = "$CARP_NAMESPACE.sensorskincontact"
     /**
      * Determines whether a sensor requiring contact with skin is making proper contact at a specific point in time.
      */
-    val SENSOR_SKIN_CONTACT = add( SENSOR_SKIN_CONTACT_TYPE_NAME, "Sensor skin contact", DataTimeType.POINT )
+    val SENSOR_SKIN_CONTACT = add(
+        SENSOR_SKIN_CONTACT_TYPE_NAME,
+        "Sensor skin contact",
+        DataTimeType.POINT
+    )
 
     internal const val NON_GRAVITATIONAL_ACCELERATION_TYPE_NAME = "$CARP_NAMESPACE.nongravitationalacceleration"
     /**
      * Rate of change in velocity, excluding gravity, along perpendicular x, y, and z axes in the device's coordinate system.
      */
-    val NON_GRAVITATIONAL_ACCELERATION = add( NON_GRAVITATIONAL_ACCELERATION_TYPE_NAME, "Acceleration without gravity", DataTimeType.POINT )
+    val NON_GRAVITATIONAL_ACCELERATION = add(
+        NON_GRAVITATIONAL_ACCELERATION_TYPE_NAME,
+        "Acceleration without gravity",
+        DataTimeType.POINT
+    )
 
     internal const val EDA_TYPE_NAME = "$CARP_NAMESPACE.eda"
     /**
      * Single-channel electrodermal activity, represented as skin conductance.
      */
-    val EDA = add( EDA_TYPE_NAME, "Electrodermal activity", DataTimeType.POINT )
+    val EDA = add(
+        EDA_TYPE_NAME,
+        "Electrodermal activity",
+        DataTimeType.POINT
+    )
 
     internal const val ACCELERATION_TYPE_NAME = "$CARP_NAMESPACE.acceleration"
     /**
      * Rate of change in velocity, including gravity, along perpendicular x, y, and z axes in the device's coordinate system.
      */
-    val ACCELERATION = add( ACCELERATION_TYPE_NAME, "Acceleration including gravity", DataTimeType.POINT )
+    val ACCELERATION = add(
+        ACCELERATION_TYPE_NAME,
+        "Acceleration including gravity",
+        DataTimeType.POINT
+    )
 
     internal const val ANGULAR_VELOCITY_TYPE_NAME = "$CARP_NAMESPACE.angularvelocity"
     /**
      * Rate of rotation around perpendicular x, y, and z axes.
      */
-    val ANGULAR_VELOCITY = add( ANGULAR_VELOCITY_TYPE_NAME, "Angular velocity", DataTimeType.POINT )
+    val ANGULAR_VELOCITY = add(
+        ANGULAR_VELOCITY_TYPE_NAME,
+        "Angular velocity",
+        DataTimeType.POINT
+    )
 
     internal const val SIGNAL_STRENGTH_TYPE_NAME = "$CARP_NAMESPACE.signalstrength"
     /**
      * The received signal strength of a wireless device.
      */
-    val SIGNAL_STRENGTH = add( SIGNAL_STRENGTH_TYPE_NAME, "Signal strength", DataTimeType.POINT )
+    val SIGNAL_STRENGTH = add(
+        SIGNAL_STRENGTH_TYPE_NAME,
+        "Signal strength",
+        DataTimeType.POINT
+    )
 
     internal const val TRIGGERED_TASK_TYPE_NAME = "$CARP_NAMESPACE.triggeredtask"
     /**
      * A task which was started or stopped by a trigger, referring to identifiers in the study protocol.
      */
-    val TRIGGERED_TASK = add( TRIGGERED_TASK_TYPE_NAME, "Triggered task", DataTimeType.POINT )
+    val TRIGGERED_TASK = add(
+        TRIGGERED_TASK_TYPE_NAME,
+        "Triggered task",
+        DataTimeType.POINT
+    )
 
     internal const val COMPLETED_TASK_TYPE_NAME = "$CARP_NAMESPACE.completedtask"
     /**
      * An interactive task which was completed over the course of a specified time interval.
      */
-    val COMPLETED_TASK = add( COMPLETED_TASK_TYPE_NAME, "Completed task", DataTimeType.TIME_SPAN )
+    val COMPLETED_TASK = add(
+        COMPLETED_TASK_TYPE_NAME,
+        "Completed task",
+        DataTimeType.TIME_SPAN
+    )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/CompletedTask.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/CompletedTask.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/Data.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/Data.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.common.application.data
 
 import dk.cachet.carp.common.application.Immutable
 import dk.cachet.carp.common.application.ImplementAsDataClass
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/ECG.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/ECG.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/EDA.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/EDA.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/Geolocation.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/Geolocation.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/HeartRate.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/HeartRate.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/InterbeatInterval.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/InterbeatInterval.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/NonGravitationalAcceleration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/NonGravitationalAcceleration.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 /**
  * Holds rate of change in velocity, excluding gravity, along perpendicular [x], [y], and [z] axes in meters per second squared (m/s^2).

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/PPG.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/PPG.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/SensorSkinContact.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/SensorSkinContact.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/SignalStrength.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/SignalStrength.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/StepCount.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/StepCount.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.application.data
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/TriggeredTask.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/TriggeredTask.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.data
 
 import dk.cachet.carp.common.application.triggers.TaskControl
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
@@ -38,7 +38,8 @@ data class CustomInput( val input: Any ) : Data
 class CustomInputSerializer( vararg supportedDataTypes: KClass<*> ) : KSerializer<CustomInput>
 {
     // TODO: Can we use the fully qualified type name to register serializers here, like kotlinx.serialization does? How?
-    val dataTypeMap: Map<String, KSerializer<out Any>> = supportedDataTypes.associate { it.simpleName!! to it.serializer() }
+    val dataTypeMap: Map<String, KSerializer<out Any>> =
+        supportedDataTypes.associate { it.simpleName!! to it.serializer() }
 
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor( CUSTOM_INPUT_TYPE_NAME )
     {

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
@@ -1,21 +1,9 @@
 package dk.cachet.carp.common.application.data.input
 
 import dk.cachet.carp.common.application.data.Data
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.SerialKind
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.descriptors.buildSerialDescriptor
-import kotlinx.serialization.descriptors.element
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.decodeStructure
-import kotlinx.serialization.encoding.encodeStructure
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
@@ -59,7 +59,7 @@ class CustomInputSerializer( vararg supportedDataTypes: KClass<*> ) : KSerialize
             val serializer = getRegisteredSerializer( dataType )
             val input = decodeSerializableElement( descriptor, 1, serializer )
 
-            return CustomInput( input )
+            CustomInput( input )
         }
 
     override fun serialize( encoder: Encoder, value: CustomInput ) =

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/InputDataTypeList.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/InputDataTypeList.kt
@@ -41,7 +41,8 @@ open class InputDataTypeList private constructor( val list: MutableList<InputDat
         dataToInput: (TData) -> TInput
     ): InputDataType =
         inputDataType.also{
-            require( !_inputElements.containsKey( it ) ) { "The specified input data type is already registered in this list." }
+            require( !_inputElements.containsKey( it ) )
+                { "The specified input data type is already registered in this list." }
 
             list.add( it )
             _inputElements[ it ] = inputElement

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/Sex.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/Sex.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.data.input
 
 import dk.cachet.carp.common.application.data.Data
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/elements/SelectOne.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/elements/SelectOne.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.common.application.data.input.elements
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/elements/Text.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/elements/Text.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.common.application.data.input.elements
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -9,8 +9,7 @@ import dk.cachet.carp.common.application.sampling.NoOptionsSamplingScheme
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.tasks.TaskConfigurationList
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -38,7 +38,8 @@ data class AltBeacon(
 
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 
-    override fun createDeviceRegistrationBuilder(): AltBeaconDeviceRegistrationBuilder = AltBeaconDeviceRegistrationBuilder()
+    override fun createDeviceRegistrationBuilder(): AltBeaconDeviceRegistrationBuilder =
+        AltBeaconDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<AltBeaconDeviceRegistration> = AltBeaconDeviceRegistration::class
     override fun isValidRegistration( registration: AltBeaconDeviceRegistration ): Trilean = Trilean.TRUE
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt
@@ -7,7 +7,7 @@ import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.NoOptionsSamplingScheme
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.tasks.TaskConfigurationList
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt
@@ -45,7 +45,8 @@ data class BLEHeartRateDevice(
     override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 
-    override fun createDeviceRegistrationBuilder(): MACAddressDeviceRegistrationBuilder = MACAddressDeviceRegistrationBuilder()
+    override fun createDeviceRegistrationBuilder(): MACAddressDeviceRegistrationBuilder =
+        MACAddressDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<MACAddressDeviceRegistration> = MACAddressDeviceRegistration::class
     override fun isValidRegistration( registration: MACAddressDeviceRegistration ): Trilean = Trilean.TRUE
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.tasks.CustomProtocolTask
 import dk.cachet.carp.common.application.tasks.TaskConfigurationList
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt
@@ -27,7 +27,8 @@ data class CustomProtocolDevice( override val roleName: String, override val isO
 
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 
-    override fun createDeviceRegistrationBuilder(): DefaultDeviceRegistrationBuilder = DefaultDeviceRegistrationBuilder()
+    override fun createDeviceRegistrationBuilder(): DefaultDeviceRegistrationBuilder =
+        DefaultDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<DefaultDeviceRegistration> = DefaultDeviceRegistration::class
     override fun isValidRegistration( registration: DefaultDeviceRegistration ) = Trilean.TRUE
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceConfiguration.kt
@@ -7,8 +7,7 @@ import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.sampling.SamplingConfigurationMapBuilder
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
@@ -5,9 +5,7 @@ import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.MACAddress
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/PrimaryDeviceConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/PrimaryDeviceConfiguration.kt
@@ -13,8 +13,10 @@ import kotlin.time.Duration
  */
 @Serializable
 @Polymorphic
-abstract class PrimaryDeviceConfiguration<TRegistration : DeviceRegistration, out TBuilder : DeviceRegistrationBuilder<TRegistration>> :
-    DeviceConfiguration<TRegistration, TBuilder>()
+abstract class PrimaryDeviceConfiguration<
+    TRegistration : DeviceRegistration,
+    out TBuilder : DeviceRegistrationBuilder<TRegistration>
+> : DeviceConfiguration<TRegistration, TBuilder>()
 {
     // This property is only here for (de)serialization purposes.
     // For unknown types we need to know whether to treat them as primary devices or not (in the case of 'DeviceConfiguration' collections).

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/PrimaryDeviceConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/PrimaryDeviceConfiguration.kt
@@ -4,6 +4,8 @@ import dk.cachet.carp.common.application.triggers.ElapsedTimeTrigger
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.time.Duration
 
 
@@ -30,3 +32,16 @@ abstract class PrimaryDeviceConfiguration<
 }
 
 typealias AnyPrimaryDeviceConfiguration = PrimaryDeviceConfiguration<*, *>
+
+
+/**
+ * Determines whether this device configuration is a primary device configuration ([AnyPrimaryDeviceConfiguration]).
+ */
+@OptIn( ExperimentalContracts::class )
+fun AnyDeviceConfiguration.isPrimary(): Boolean
+{
+    contract {
+        returns( true ) implies( this@isPrimary is AnyPrimaryDeviceConfiguration )
+    }
+    return this is AnyPrimaryDeviceConfiguration
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/PrimaryDeviceConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/PrimaryDeviceConfiguration.kt
@@ -1,9 +1,7 @@
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.triggers.ElapsedTimeTrigger
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlin.time.Duration

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -1,5 +1,3 @@
-@file:Suppress( "WildcardImport" )
-
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.Trilean

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.common.application.data.CarpDataTypes
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.sampling.*
 import dk.cachet.carp.common.application.tasks.*
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.milliseconds
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -52,7 +52,7 @@ data class Smartphone(
          *       Each 'step' is reported as an event, so this would map to a different DataType (e.g. `Step`).
          *       Not certain this is available on iPhone.
          */
-        val STEP_COUNT = add( NoOptionsSamplingScheme( CarpDataTypes.STEP_COUNT ) ) // No configuration options available.
+        val STEP_COUNT = add( NoOptionsSamplingScheme( CarpDataTypes.STEP_COUNT ) ) // No options available.
 
         /**
          * Rate of change in velocity, excluding gravity, along perpendicular x, y, and z axes in the device's coordinate system,
@@ -114,7 +114,8 @@ data class Smartphone(
     override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
     override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
 
-    override fun createDeviceRegistrationBuilder(): SmartphoneDeviceRegistrationBuilder = SmartphoneDeviceRegistrationBuilder()
+    override fun createDeviceRegistrationBuilder(): SmartphoneDeviceRegistrationBuilder =
+        SmartphoneDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<SmartphoneDeviceRegistration> = SmartphoneDeviceRegistration::class
     override fun isValidRegistration( registration: SmartphoneDeviceRegistration ) = Trilean.TRUE
 }
@@ -138,24 +139,24 @@ class SmartphoneSamplingConfigurationMapBuilder : SamplingConfigurationMapBuilde
     /**
      * Configure sampling configuration for [CarpDataTypes.GEOLOCATION].
      */
-    fun geolocation( builder: AdaptiveGranularitySamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun geolocation( builder: AdaptiveGranularitySamplingConfigurationBuilder.() -> Unit ) =
         addConfiguration( Smartphone.Sensors.GEOLOCATION, builder )
 
     /**
      * Configure sampling configuration for [CarpDataTypes.NON_GRAVITATIONAL_ACCELERATION].
      */
-    fun nonGravitationalAcceleration( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun nonGravitationalAcceleration( builder: IntervalSamplingConfigurationBuilder.() -> Unit ) =
         addConfiguration( Smartphone.Sensors.NON_GRAVITATIONAL_ACCELERATION, builder )
 
     /**
      * Configure sampling configuration for [CarpDataTypes.ACCELERATION].
      */
-    fun acceleration( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun acceleration( builder: IntervalSamplingConfigurationBuilder.() -> Unit ) =
         addConfiguration( Smartphone.Sensors.ACCELERATION, builder )
 
     /**
      * Configure sampling configuration for [CarpDataTypes.ANGULAR_VELOCITY].
      */
-    fun angularVelocity( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun angularVelocity( builder: IntervalSamplingConfigurationBuilder.() -> Unit ) =
         addConfiguration( Smartphone.Sensors.ANGULAR_VELOCITY, builder )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.common.application.sampling
 
 import dk.cachet.carp.common.application.data.DataTypeMetaData
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.common.application.sampling
 
 import dk.cachet.carp.common.application.data.DataTypeMetaData
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.common.application.sampling
 import dk.cachet.carp.common.application.data.DataTypeMetaData
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
 import dk.cachet.carp.common.infrastructure.serialization.DurationSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.time.Duration
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common.application.sampling
 
 import dk.cachet.carp.common.application.data.DataTypeMetaData
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.services
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/BackgroundTask.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/BackgroundTask.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.common.application.tasks
 
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.infrastructure.serialization.DurationSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.time.Duration
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/CustomProtocolTask.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/CustomProtocolTask.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common.application.tasks
 
 import dk.cachet.carp.common.application.data.NoData
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/Measure.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/Measure.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.common.application.tasks
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/TaskConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/TaskConfiguration.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.application.data.CarpDataTypes
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.DataType
-import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/TaskConfigurationList.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/TaskConfigurationList.kt
@@ -9,8 +9,9 @@ import dk.cachet.carp.common.application.devices.DeviceConfiguration
  *
  * Extend from this class as an object and assign members as follows: `val SOME_TASK = add { SomeTaskBuilder() }`.
  */
-open class TaskConfigurationList private constructor( private val list: MutableList<SupportedTaskConfiguration<*, *>> ) :
-    List<SupportedTaskConfiguration<*, *>> by list
+open class TaskConfigurationList private constructor(
+    private val list: MutableList<SupportedTaskConfiguration<*, *>>
+) : List<SupportedTaskConfiguration<*, *>> by list
 {
     constructor() : this( mutableListOf() )
 
@@ -18,22 +19,25 @@ open class TaskConfigurationList private constructor( private val list: MutableL
      * All containing measures and/or outputs start running in the background once triggered.
      * The task runs for a specified duration, or until stopped, or until all measures and/or outputs have completed.
      */
-    @Suppress("PropertyName", "VariableNaming" ) // This class should only be extended by object classes, making it a constant.
+    @Suppress("PropertyName", "VariableNaming" ) // This is only extended by object classes, making it a constant.
     val BACKGROUND = add { BackgroundTaskBuilder() }
 
 
-    protected fun <TConfiguration : TaskConfiguration<*>, TBuilder : TaskConfigurationBuilder<TConfiguration>> add(
-        builder: () -> TBuilder
-    ): SupportedTaskConfiguration<TConfiguration, TBuilder> = SupportedTaskConfiguration( builder ).also { list.add( it ) }
+    protected fun <
+        TConfiguration : TaskConfiguration<*>,
+        TBuilder : TaskConfigurationBuilder<TConfiguration>
+    > add( builder: () -> TBuilder ): SupportedTaskConfiguration<TConfiguration, TBuilder> =
+        SupportedTaskConfiguration( builder ).also { list.add( it ) }
 }
 
 
 /**
  * A [TaskConfiguration] which is listed as a supported task on a [DeviceConfiguration].
  */
-class SupportedTaskConfiguration<TConfiguration : TaskConfiguration<*>, TBuilder : TaskConfigurationBuilder<TConfiguration>>(
-    private val createBuilder: () -> TBuilder
-)
+class SupportedTaskConfiguration<
+    TConfiguration : TaskConfiguration<*>,
+    TBuilder : TaskConfigurationBuilder<TConfiguration>
+>( private val createBuilder: () -> TBuilder )
 {
     /**
      * Create a [TaskConfiguration] supported on this device with [name] which uniquely defines the task.

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/WebTask.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/WebTask.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.common.application.tasks
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.tasks.WebTask.UrlVariable
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ElapsedTimeTrigger.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ElapsedTimeTrigger.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.common.application.triggers
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
 import dk.cachet.carp.common.infrastructure.serialization.DurationSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
 import kotlin.time.Duration
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ManualTrigger.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ManualTrigger.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.triggers
 
 import dk.cachet.carp.common.application.data.NoData
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ScheduledTrigger.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ScheduledTrigger.kt
@@ -4,8 +4,7 @@ import dk.cachet.carp.common.application.RecurrenceRule
 import dk.cachet.carp.common.application.TimeOfDay
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/TaskControl.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/TaskControl.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.common.application.triggers
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/TriggerConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/TriggerConfiguration.kt
@@ -5,9 +5,7 @@ import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
 import dk.cachet.carp.common.application.devices.PrimaryDeviceConfiguration
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/AccountIdentity.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/AccountIdentity.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.users
 
 import dk.cachet.carp.common.application.EmailAddress
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/AssignedTo.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/AssignedTo.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.common.application.users
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ExpectedParticipantData.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ExpectedParticipantData.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common.application.users
 
 import dk.cachet.carp.common.application.data.input.InputDataType
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantAttribute.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantAttribute.kt
@@ -8,7 +8,7 @@ import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.data.input.InputDataTypeList
 import dk.cachet.carp.common.application.data.input.elements.AnyInputElement
 import dk.cachet.carp.common.application.data.input.elements.InputElement
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantAttribute.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantAttribute.kt
@@ -117,7 +117,11 @@ sealed class ParticipantAttribute
         val isCorrectDataType = when ( this )
         {
             is CustomParticipantAttribute<*> -> data is CustomInput && isValidCustomData( inputElement, data )
-            is DefaultParticipantAttribute -> registeredInputDataTypes.dataClasses[ inputDataType ]!!.isInstance( data )
+            is DefaultParticipantAttribute ->
+            {
+                val dataClass = checkNotNull( registeredInputDataTypes.dataClasses[ inputDataType ] )
+                dataClass.isInstance(data)
+            }
         }
         if ( !isCorrectDataType ) return false
 
@@ -150,8 +154,8 @@ sealed class ParticipantAttribute
         // Convert to input data.
         val converter = registeredInputDataTypes.dataToInputConverters[ inputDataType ]
             ?: throw UnsupportedOperationException( "No data converter for '$inputDataType' registered." )
-        require( registeredInputDataTypes.dataClasses[ inputDataType ]!!.isInstance( data ) )
-            { "Data is not of expected type for this attribute." }
+        val dataClass = checkNotNull( registeredInputDataTypes.dataClasses[ inputDataType ] )
+        require( dataClass.isInstance( data ) ) { "Data is not of expected type for this attribute." }
         return converter( data )
     }
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantRole.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantRole.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.common.application.users
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/Username.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/Username.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.application.users
 
 import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/domain/users/Account.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/domain/users/Account.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.common.application.users.Username
 import dk.cachet.carp.common.application.users.UsernameAccountIdentity
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/ApplicationDataSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/ApplicationDataSerializer.kt
@@ -1,17 +1,10 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonEncoder
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapper.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapper.kt
@@ -25,7 +25,9 @@ object CustomSerializerWrapperSerializer : KSerializer<CustomSerializerWrapper>
         encoder.encodeSerializableValue( value.serializer, value.inner )
 
     override fun deserialize( decoder: Decoder ): CustomSerializerWrapper =
-        throw UnsupportedOperationException( "${CustomSerializerWrapper::class.simpleName} only supports serialization." )
+        throw UnsupportedOperationException(
+            "${CustomSerializerWrapper::class.simpleName} only supports serialization."
+        )
 }
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapper.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapper.kt
@@ -1,11 +1,8 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/MapAsArraySerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/MapAsArraySerializer.kt
@@ -1,11 +1,9 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/NotSerializable.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/NotSerializable.kt
@@ -1,11 +1,8 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlin.reflect.KFunction1
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/PolymorphicEnumSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/PolymorphicEnumSerializer.kt
@@ -1,13 +1,8 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.decodeStructure
-import kotlinx.serialization.encoding.encodeStructure
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/PolymorphicEnumSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/PolymorphicEnumSerializer.kt
@@ -31,7 +31,7 @@ class PolymorphicEnumSerializer<T : Enum<T>>( private val enumSerializer: KSeria
         decoder.decodeStructure( descriptor )
         {
             decodeElementIndex( descriptor )
-            return decodeSerializableElement( descriptor, 0, enumSerializer )
+            decodeSerializableElement( descriptor, 0, enumSerializer )
         }
 
     override fun serialize( encoder: Encoder, value: T ) =

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
@@ -1,5 +1,3 @@
-@file:Suppress( "WildcardImport" )
-
 package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.application.data.*

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
@@ -8,8 +8,7 @@ import dk.cachet.carp.common.application.sampling.*
 import dk.cachet.carp.common.application.tasks.*
 import dk.cachet.carp.common.application.triggers.*
 import dk.cachet.carp.common.application.users.*
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.*
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDataSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDataSerializers.kt
@@ -17,5 +17,6 @@ data class CustomData( override val className: String, override val jsonSource: 
 /**
  * Custom serializer for [Data] which enables deserializing types that are unknown at runtime, yet extend from [Data].
  */
-object DataSerializer : KSerializer<Data>
-    by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomData( className, json, serializer ) } )
+object DataSerializer : KSerializer<Data> by createUnknownPolymorphicSerializer(
+    { className, json, serializer -> CustomData( className, json, serializer ) }
+)

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDataSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDataSerializers.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.application.data.Data
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -36,7 +36,9 @@ data class CustomDeviceConfiguration(
     // This information is not serialized. Therefore, the supported types and sampling schemes are unknown.
     override fun getSupportedDataTypes(): Set<DataType> = emptySet()
     override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap =
-        throw UnsupportedOperationException( "The concrete type of this device is not known. Therefore, sampling schemes are unknown." )
+        throw UnsupportedOperationException(
+            "The concrete type of this device is not known. Therefore, sampling schemes are unknown."
+        )
 
     init
     {
@@ -48,7 +50,10 @@ data class CustomDeviceConfiguration(
     }
 
     override fun createDeviceRegistrationBuilder(): DeviceRegistrationBuilder<DeviceRegistration> =
-        throw UnsupportedOperationException( "The concrete type of this device is not known. Therefore, it is unknown which registration builder is required." )
+        throw UnsupportedOperationException(
+            "The concrete type of this device is not known. " +
+            "Therefore, it is unknown which registration builder is required."
+        )
 
     override fun getRegistrationClass(): KClass<DeviceRegistration> = DeviceRegistration::class
 
@@ -68,7 +73,8 @@ data class CustomPrimaryDeviceConfiguration(
     override val className: String,
     override val jsonSource: String,
     val serializer: Json
-) : PrimaryDeviceConfiguration<DeviceRegistration, DeviceRegistrationBuilder<DeviceRegistration>>(), UnknownPolymorphicWrapper
+) : PrimaryDeviceConfiguration<DeviceRegistration, DeviceRegistrationBuilder<DeviceRegistration>>(),
+    UnknownPolymorphicWrapper
 {
     override val roleName: String
     override val isOptional: Boolean
@@ -78,7 +84,9 @@ data class CustomPrimaryDeviceConfiguration(
     // This information is not serialized. Therefore, the supported types and sampling schemes are unknown.
     override fun getSupportedDataTypes(): Set<DataType> = emptySet()
     override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap =
-        throw UnsupportedOperationException( "The concrete type of this device is not known. Therefore, sampling schemes are unknown." )
+        throw UnsupportedOperationException(
+            "The concrete type of this device is not known. Therefore, sampling schemes are unknown."
+        )
 
     init
     {
@@ -90,7 +98,10 @@ data class CustomPrimaryDeviceConfiguration(
     }
 
     override fun createDeviceRegistrationBuilder(): DeviceRegistrationBuilder<DeviceRegistration> =
-        throw UnsupportedOperationException( "The concrete type of this device is not known. Therefore, it is unknown which registration builder is required." )
+        throw UnsupportedOperationException(
+            "The concrete type of this device is not known. " +
+            "Therefore, it is unknown which registration builder is required."
+        )
 
     override fun getRegistrationClass(): KClass<DeviceRegistration> = DeviceRegistration::class
 
@@ -124,7 +135,11 @@ private data class BaseMembers(
 /**
  * Custom serializer for [DeviceConfiguration] which enables deserializing types that are unknown at runtime, yet extend from [DeviceConfiguration].
  */
-object DeviceConfigurationSerializer : UnknownPolymorphicSerializer<AnyDeviceConfiguration, AnyDeviceConfiguration>( DeviceConfiguration::class, DeviceConfiguration::class, false )
+object DeviceConfigurationSerializer : UnknownPolymorphicSerializer<AnyDeviceConfiguration, AnyDeviceConfiguration>(
+    DeviceConfiguration::class,
+    DeviceConfiguration::class,
+    verifyUnknownPolymorphicWrapper = false
+)
 {
     override fun createWrapper( className: String, json: String, serializer: Json ): AnyDeviceConfiguration
     {
@@ -146,7 +161,9 @@ object DeviceConfigurationSerializer : UnknownPolymorphicSerializer<AnyDeviceCon
  * Custom serializer for [PrimaryDeviceConfiguration] which enables deserializing types that are unknown at runtime, yet extend from [PrimaryDeviceConfiguration].
  */
 object PrimaryDeviceConfigurationSerializer : KSerializer<AnyPrimaryDeviceConfiguration>
-    by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomPrimaryDeviceConfiguration( className, json, serializer ) } )
+    by createUnknownPolymorphicSerializer(
+        { className, json, serializer -> CustomPrimaryDeviceConfiguration( className, json, serializer ) }
+    )
 
 
 /**
@@ -181,5 +198,6 @@ data class CustomDeviceRegistration(
 /**
  * Custom serializer for a [DeviceRegistration] which enables deserializing types that are unknown at runtime, yet extend from [DeviceRegistration].
  */
-object DeviceRegistrationSerializer : KSerializer<DeviceRegistration>
-    by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomDeviceRegistration( className, json, serializer ) } )
+object DeviceRegistrationSerializer : KSerializer<DeviceRegistration> by createUnknownPolymorphicSerializer(
+    { className, json, serializer -> CustomDeviceRegistration( className, json, serializer ) }
+)

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -10,10 +10,8 @@ import dk.cachet.carp.common.application.devices.DeviceRegistrationBuilder
 import dk.cachet.carp.common.application.devices.PrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
@@ -2,18 +2,10 @@ package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.infrastructure.reflect.AccessInternals
 import dk.cachet.carp.common.infrastructure.reflect.reflectIfAvailable
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonEncoder
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
@@ -49,10 +49,7 @@ abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
         if ( reflect != null && verifyUnknownPolymorphicWrapper )
         {
             val implementsInterface: Boolean = reflect.extendsType<UnknownPolymorphicWrapper>( wrapperClass )
-            if ( !implementsInterface )
-            {
-                throw IllegalArgumentException( "'$wrapperClass' must implement '${UnknownPolymorphicWrapper::class}'." )
-            }
+            require( implementsInterface ) { "'$wrapperClass' must implement '${UnknownPolymorphicWrapper::class}'." }
         }
     }
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownSamplingConfigurationSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownSamplingConfigurationSerializers.kt
@@ -20,5 +20,6 @@ data class CustomSamplingConfiguration(
 /**
  * Custom serializer for a [SamplingConfiguration] which enables deserializing types that are unknown at runtime, yet extend from [SamplingConfiguration].
  */
-object SamplingConfigurationSerializer : KSerializer<SamplingConfiguration>
-    by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomSamplingConfiguration( className, json, serializer ) } )
+object SamplingConfigurationSerializer : KSerializer<SamplingConfiguration> by createUnknownPolymorphicSerializer(
+    { className, json, serializer -> CustomSamplingConfiguration( className, json, serializer ) }
+)

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownSamplingConfigurationSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownSamplingConfigurationSerializers.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTaskSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTaskSerializers.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.common.infrastructure.serialization
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.tasks.Measure
 import dk.cachet.carp.common.application.tasks.TaskConfiguration
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTaskSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTaskSerializers.kt
@@ -42,5 +42,6 @@ data class CustomTaskConfiguration(
 /**
  * Custom serializer for [TaskConfiguration] which enables deserializing types that are unknown at runtime, yet extend from [TaskConfiguration].
  */
-object TaskConfigurationSerializer : KSerializer<TaskConfiguration<*>>
-    by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomTaskConfiguration( className, json, serializer ) } )
+object TaskConfigurationSerializer : KSerializer<TaskConfiguration<*>> by createUnknownPolymorphicSerializer(
+    { className, json, serializer -> CustomTaskConfiguration( className, json, serializer ) }
+)

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTriggerSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTriggerSerializers.kt
@@ -34,5 +34,6 @@ data class CustomTriggerConfiguration(
 /**
  * Custom serializer for a [TriggerConfiguration] which enables deserializing types that are unknown at runtime, yet extend from [TriggerConfiguration].
  */
-object TriggerConfigurationSerializer : KSerializer<TriggerConfiguration<*>>
-    by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomTriggerConfiguration( className, json, serializer ) } )
+object TriggerConfigurationSerializer : KSerializer<TriggerConfiguration<*>> by createUnknownPolymorphicSerializer(
+    { className, json, serializer -> CustomTriggerConfiguration( className, json, serializer ) }
+)

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTriggerSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTriggerSerializers.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.triggers.TriggerConfiguration
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxy.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxy.kt
@@ -153,12 +153,13 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
             override fun serialize( encoder: Encoder, value: LoggedRequest.Succeeded<*, *> )
             {
                 val responseSerializer = value.request.getResponseSerializer() as KSerializer<Any?>
+                val anyEventsSerializer = eventsSerializer as KSerializer<Any>
 
                 encoder.encodeStructure( descriptor )
                 {
                     encodeSerializableElement( descriptor, 0, requestSerializer as KSerializer<Any>, value.request )
-                    encodeSerializableElement( descriptor, 1, eventsSerializer as KSerializer<Any>, value.precedingEvents )
-                    encodeSerializableElement( descriptor, 2, eventsSerializer as KSerializer<Any>, value.publishedEvents )
+                    encodeSerializableElement( descriptor, 1, anyEventsSerializer, value.precedingEvents )
+                    encodeSerializableElement( descriptor, 2, anyEventsSerializer, value.publishedEvents )
                     encodeSerializableElement( descriptor, 3, responseSerializer, value.response )
                 }
             }
@@ -180,7 +181,11 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
                             0 -> request = decodeSerializableElement( descriptor, 0, requestSerializer )
                             1 -> precedingEvents = decodeSerializableElement( descriptor, 1, eventsSerializer )
                             2 -> publishedEvents = decodeSerializableElement( descriptor, 2, eventsSerializer )
-                            3 -> response = decodeSerializableElement( descriptor, 3, request!!.getResponseSerializer() )
+                            3 ->
+                            {
+                                val responseSerializer = checkNotNull( request ).getResponseSerializer()
+                                response = decodeSerializableElement( descriptor, 3, responseSerializer )
+                            }
                             CompositeDecoder.DECODE_DONE -> decoding = false
                             else -> error( "Unexpected index: $index" )
                         }
@@ -213,11 +218,13 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
             @Suppress( "UNCHECKED_CAST" )
             override fun serialize( encoder: Encoder, value: LoggedRequest.Failed<*, *> )
             {
+                val anyEventsSerializer = eventsSerializer as KSerializer<Any>
+
                 encoder.encodeStructure( descriptor )
                 {
                     encodeSerializableElement( descriptor, 0, requestSerializer as KSerializer<Any>, value.request )
-                    encodeSerializableElement( descriptor, 1, eventsSerializer as KSerializer<Any>, value.precedingEvents )
-                    encodeSerializableElement( descriptor, 2, eventsSerializer as KSerializer<Any>, value.publishedEvents )
+                    encodeSerializableElement( descriptor, 1, anyEventsSerializer, value.precedingEvents )
+                    encodeSerializableElement( descriptor, 2, anyEventsSerializer, value.publishedEvents )
                     encodeSerializableElement( descriptor, 3, exceptionSerializer, value.exceptionType )
                 }
             }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxy.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxy.kt
@@ -3,20 +3,11 @@ package dk.cachet.carp.common.infrastructure.services
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.infrastructure.reflect.AccessInternals
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SealedClassSerializer
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.encoding.CompositeDecoder
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.decodeStructure
-import kotlinx.serialization.encoding.encodeStructure
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.JsonClassDiscriminator
-import kotlinx.serialization.serializer
 
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxy.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxy.kt
@@ -172,7 +172,8 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
                     var publishedEvents: List<TEvent>? = null
                     var response: Any? = null
 
-                    while ( true )
+                    var decoding = true
+                    while ( decoding )
                     {
                         when ( val index = decodeElementIndex( descriptor ) )
                         {
@@ -180,7 +181,7 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
                             1 -> precedingEvents = decodeSerializableElement( descriptor, 1, eventsSerializer )
                             2 -> publishedEvents = decodeSerializableElement( descriptor, 2, eventsSerializer )
                             3 -> response = decodeSerializableElement( descriptor, 3, request!!.getResponseSerializer() )
-                            CompositeDecoder.DECODE_DONE -> break
+                            CompositeDecoder.DECODE_DONE -> decoding = false
                             else -> error( "Unexpected index: $index" )
                         }
                     }
@@ -230,7 +231,8 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
                     var publishedEvents: List<TEvent>? = null
                     var exceptionType: String? = null
 
-                    while ( true )
+                    var decoding = true
+                    while ( decoding )
                     {
                         when ( val index = decodeElementIndex( descriptor ) )
                         {
@@ -238,7 +240,7 @@ class LoggedRequestSerializer<TService : ApplicationService<TService, TEvent>, T
                             1 -> precedingEvents = decodeSerializableElement( descriptor, 1, eventsSerializer )
                             2 -> publishedEvents = decodeSerializableElement( descriptor, 2, eventsSerializer )
                             3 -> exceptionType = decodeSerializableElement( descriptor, 3, exceptionSerializer )
-                            CompositeDecoder.DECODE_DONE -> break
+                            CompositeDecoder.DECODE_DONE -> decoding = false
                             else -> error( "Unexpected index: $index" )
                         }
                     }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/CreateTestObjects.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/CreateTestObjects.kt
@@ -13,11 +13,7 @@ import dk.cachet.carp.common.infrastructure.serialization.COMMON_SERIAL_MODULE
 import dk.cachet.carp.common.infrastructure.serialization.createDefaultJSON
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.PolymorphicModuleBuilder
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.plus
-import kotlinx.serialization.modules.polymorphic
-import kotlinx.serialization.modules.subclass
+import kotlinx.serialization.modules.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubData.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubData.kt
@@ -2,9 +2,7 @@ package dk.cachet.carp.common.infrastructure.test
 
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.SensorData
-import kotlinx.serialization.Required
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubDeviceConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubDeviceConfiguration.kt
@@ -7,8 +7,7 @@ import dk.cachet.carp.common.application.devices.DefaultDeviceRegistrationBuilde
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubPrimaryDeviceConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubPrimaryDeviceConfiguration.kt
@@ -7,8 +7,7 @@ import dk.cachet.carp.common.application.devices.DefaultDeviceRegistrationBuilde
 import dk.cachet.carp.common.application.devices.PrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubSamplingConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubSamplingConfiguration.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.common.infrastructure.test
 
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.sampling.SamplingConfigurationBuilder
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubTaskConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubTaskConfiguration.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.common.infrastructure.test
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.tasks.Measure
 import dk.cachet.carp.common.application.tasks.TaskConfiguration
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubTriggerConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubTriggerConfiguration.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.common.infrastructure.test
 import dk.cachet.carp.common.application.data.NoData
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.triggers.TriggerConfiguration
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/TestInstances.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/TestInstances.kt
@@ -1,5 +1,3 @@
-@file:Suppress( "WildcardImport" )
-
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.application.data.*

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/UUIDTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/UUIDTest.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.infrastructure.serialization.createDefaultJSON
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/SamplingConfigurationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/SamplingConfigurationTest.kt
@@ -13,7 +13,7 @@ class SamplingConfigurationMapBuilderTest
 {
     class TestBuilder : SamplingConfigurationMapBuilder()
     {
-        fun someSampleConfiguration( builder: NoOptionsSamplingConfigurationBuilder.() -> Unit = { } ): SamplingConfiguration =
+        fun someSampleConfiguration( builder: NoOptionsSamplingConfigurationBuilder.() -> Unit = { } ) =
             addConfiguration( StubDataTypeSamplingScheme(), builder )
     }
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/ApplicationServiceEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/ApplicationServiceEventBusTest.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.common.application.services
 
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/IntegrationEventTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/IntegrationEventTest.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.common.application.services
 
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/ApplicationDataSerializerTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/ApplicationDataSerializerTest.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/CarpPrimitiveSerializerTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/CarpPrimitiveSerializerTest.kt
@@ -1,9 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapperTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapperTest.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.*

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/InputElementTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/InputElementTest.kt
@@ -2,8 +2,8 @@ package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.application.data.input.elements.InputElement
 import dk.cachet.carp.common.application.data.input.elements.Text
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.builtins.SetSerializer
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/NotSerializableTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/NotSerializableTest.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/PolymorphicEnumSerializerTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/PolymorphicEnumSerializerTest.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress( "WildcardImport" )
-
 package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.application.commonInstances

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.common.infrastructure.serialization
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistration
 import dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration
 import dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializerTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializerTest.kt
@@ -1,13 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Polymorphic
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.decodeFromHexString
-import kotlinx.serialization.encodeToHexString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownSamplingConfigurationSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownSamplingConfigurationSerializersTest.kt
@@ -2,7 +2,7 @@
 
 package dk.cachet.carp.common.infrastructure.serialization
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTaskSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTaskSerializersTest.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.application.tasks.Measure
 import dk.cachet.carp.common.infrastructure.test.STUBS_SERIAL_MODULE
 import dk.cachet.carp.common.infrastructure.test.STUB_DATA_POINT_TYPE
 import dk.cachet.carp.common.infrastructure.test.StubTaskConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTriggerSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownTriggerSerializersTest.kt
@@ -3,7 +3,7 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
 import dk.cachet.carp.common.infrastructure.test.StubTriggerConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxyTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLoggingProxyTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.*
 /**
  * Tests for [ApplicationServiceLoggingProxy] relying on core infrastructure.
  */
-class ApplicationServiceLogTest
+class ApplicationServiceLoggingProxyTest
 {
     @Test
     fun can_serialize_and_deserialize_LoggedRequest_Succeeded()

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequestTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequestTest.kt
@@ -5,13 +5,8 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ChannelConventionEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ChannelConventionEventBusTest.kt
@@ -5,8 +5,7 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.services.publish
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/SingleThreadedEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/SingleThreadedEventBusTest.kt
@@ -6,8 +6,7 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.services.publish
 import dk.cachet.carp.common.application.services.registerHandler
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApiJsonObjectMigrationBuilderTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApiJsonObjectMigrationBuilderTest.kt
@@ -1,16 +1,9 @@
 package dk.cachet.carp.common.infrastructure.versioning
 
 import dk.cachet.carp.common.infrastructure.serialization.createDefaultJSON
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
-import kotlinx.serialization.modules.subclass
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlinx.serialization.modules.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApplicationServiceApiMigratorTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApplicationServiceApiMigratorTest.kt
@@ -7,14 +7,9 @@ import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.*
 import kotlin.test.*
 
 

--- a/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -1,48 +1,24 @@
+@file:Suppress("MatchingDeclarationName")
+
 package dk.cachet.carp.common.application
 
-import kotlinx.serialization.Serializable
 
-
-@Serializable( UUIDSerializer::class )
-actual class UUID actual constructor( actual val stringRepresentation: String )
+actual object DefaultUUIDFactory : UUIDFactory
 {
-    init
+    private const val base = 16
+
+    actual override fun randomUUID(): UUID
     {
-        require( UUIDRegex.matches( stringRepresentation ) ) { "Invalid UUID string representation." }
-    }
-
-
-    actual companion object : UUIDFactory
-    {
-        actual fun parse( uuid: String ): UUID = UUID( uuid.lowercase() )
-
-        private const val base = 16
-        actual override fun randomUUID(): UUID
-        {
-            // It does not seem like JS can generate true UUIDs, but this is a best effort:
-            // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-            // Regardless, we do not need to support UUID generation in JS, as this is used as client-side code.
-            // The only real reason for providing a best effort implementation here is to be able to run unit tests.
-            val uuidString = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace( Regex( "[xy]" ) ) { match ->
-                val random = js("Math.random() * $base | 0")
-                val char = if ( match.value == "x" ) random else js( "random & 0x3 | 0x8" )
-                char.toString( base ) as CharSequence
-            }
-
-            return UUID( uuidString )
+        // It does not seem like JS can generate true UUIDs, but this is a best effort:
+        // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+        // Regardless, we do not need to support UUID generation in JS, as this is used as client-side code.
+        // The only real reason for providing a best effort implementation here is to be able to run unit tests.
+        val uuidString = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace( Regex( "[xy]" ) ) { match ->
+            val random = js("Math.random() * $base | 0")
+            val char = if ( match.value == "x" ) random else js( "random & 0x3 | 0x8" )
+            char.toString( base ) as CharSequence
         }
+
+        return UUID( uuidString )
     }
-
-
-    actual override fun toString(): String = stringRepresentation
-
-    override fun equals( other: Any? ): Boolean
-    {
-        if ( this === other ) return true
-        if ( other !is UUID ) return false
-
-        return stringRepresentation == other.stringRepresentation
-    }
-
-    override fun hashCode(): Int = stringRepresentation.hashCode()
 }

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
@@ -8,10 +8,7 @@ import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.common.infrastructure.services.LoggedRequestSerializer
 import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SealedClassSerializer
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 import java.net.URI
 import kotlin.reflect.KClass
 

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.DependentServices
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
+import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.common.infrastructure.services.LoggedRequestSerializer
 import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
 import kotlinx.serialization.InternalSerializationApi
@@ -106,7 +107,7 @@ class ApplicationServiceInfo private constructor( val serviceKlass: ServiceClass
 
     val requestObjectSerializer: KSerializer<out ApplicationServiceRequest<*, *>>
     val eventSerializer: KSerializer<IntegrationEvent<*>>
-    val loggedRequestSerializer: LoggedRequestSerializer<*>
+    val loggedRequestSerializer: KSerializer<LoggedRequest<*, *>>
     val apiMigrator: ApplicationServiceApiMigrator<*>
 
     val requestSchemaUri: URI
@@ -179,7 +180,11 @@ class ApplicationServiceInfo private constructor( val serviceKlass: ServiceClass
             allSubclassSerializers.values.toTypedArray()
         )
 
-        loggedRequestSerializer = LoggedRequestSerializer( requestObjectSerializer, eventSerializer )
+        @Suppress( "UNCHECKED_CAST" )
+        loggedRequestSerializer = LoggedRequestSerializer(
+            requestObjectSerializer as KSerializer<out ApplicationServiceRequest<Nothing, *>>,
+            eventSerializer as KSerializer<out IntegrationEvent<Nothing>>
+        )
 
         // Get application service API migrator.
         val apiMigratorName = "${serviceName}ApiMigrator"

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
@@ -96,7 +96,7 @@ class ApplicationServiceInfo private constructor( val serviceKlass: ServiceClass
     val serviceName: String = serviceKlass.simpleName
     val apiVersion: ApiVersion
     val dependentServices: List<ServiceClass> = serviceKlass.getAnnotation( DependentServices::class.java )
-        ?.service?.map { it.java } ?: emptyList()
+        ?.service?.map { it.java }.orEmpty()
 
     val subsystemName: String
     val subsystemNamespace: String

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -1,33 +1,9 @@
+
+@file:Suppress("MatchingDeclarationName")
 package dk.cachet.carp.common.application
 
-import kotlinx.serialization.Serializable
 
-
-@Serializable( UUIDSerializer::class )
-actual class UUID actual constructor( actual val stringRepresentation: String )
+actual object DefaultUUIDFactory : UUIDFactory
 {
-    init
-    {
-        require( UUIDRegex.matches( stringRepresentation ) ) { "Invalid UUID string representation." }
-    }
-
-
-    actual companion object : UUIDFactory
-    {
-        actual fun parse( uuid: String ): UUID = UUID( uuid.lowercase() )
-        actual override fun randomUUID(): UUID = UUID( java.util.UUID.randomUUID().toString() )
-    }
-
-
-    actual override fun toString(): String = stringRepresentation
-
-    override fun equals( other: Any? ): Boolean
-    {
-        if ( this === other ) return true
-        if ( other !is UUID ) return false
-
-        return stringRepresentation == other.stringRepresentation
-    }
-
-    override fun hashCode(): Int = stringRepresentation.hashCode()
+    actual override fun randomUUID(): UUID = UUID( java.util.UUID.randomUUID().toString() )
 }

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -1,5 +1,5 @@
+@file:Suppress( "MatchingDeclarationName" )
 
-@file:Suppress("MatchingDeclarationName")
 package dk.cachet.carp.common.application
 
 

--- a/carp.common/src/jvmTest/kotlin/dk/cachet/carp/common/application/data/CarpDataTypesReflectionTest.kt
+++ b/carp.common/src/jvmTest/kotlin/dk/cachet/carp/common/application/data/CarpDataTypesReflectionTest.kt
@@ -3,9 +3,7 @@ package dk.cachet.carp.common.application.data
 import dk.cachet.carp.common.application.concreteDataTypes
 import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.CustomInput
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
@@ -1,12 +1,10 @@
 package dk.cachet.carp.data.application
 
 import dk.cachet.carp.common.application.data.Data
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
@@ -21,19 +21,18 @@ interface DataStreamBatch : Sequence<DataStreamPoint<*>>
     /**
      * Get an iterator to iterate over all [DataStreamPoint]s contained in this batch.
      */
-    override fun iterator(): Iterator<DataStreamPoint<*>> =
-        sequences.asSequence().flatMap { seq -> seq.map { it } }.iterator()
+    override fun iterator(): Iterator<DataStreamPoint<*>> = sequences.flatMap { it }.iterator()
 
     /**
      * Determines whether this [DataStreamBatch] contains no [DataStreamPoint]s.
      */
-    fun isEmpty(): Boolean = firstOrNull() == null
+    fun isEmpty(): Boolean = none()
 
     /**
      * Get all [DataStreamPoint]s for [dataStream] in this batch, in order.
      */
     fun getDataStreamPoints( dataStream: DataStreamId ): Sequence<DataStreamPoint<*>> =
-        sequences.filter { it.dataStream == dataStream }.flatMap { sequence -> sequence.map { it } }
+        sequences.filter { it.dataStream == dataStream }.flatMap { it }
 }
 
 

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamId.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamId.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.data.application
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.DataType
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamPoint.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamPoint.kt
@@ -2,9 +2,7 @@ package dk.cachet.carp.data.application
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamSequence.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamSequence.kt
@@ -1,11 +1,9 @@
 package dk.cachet.carp.data.application
 
 import dk.cachet.carp.common.application.data.Data
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
@@ -5,8 +5,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamsConfiguration.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamsConfiguration.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.data.application
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.DataType
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/Measurement.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/Measurement.kt
@@ -4,11 +4,9 @@ import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.DataTimeType
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.data.infrastructure.getDataType
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/SyncPoint.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/SyncPoint.kt
@@ -1,8 +1,8 @@
 package dk.cachet.carp.data.application
 
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
@@ -9,10 +9,7 @@ import dk.cachet.carp.data.application.DataStreamBatchSerializer
 import dk.cachet.carp.data.application.DataStreamId
 import dk.cachet.carp.data.application.DataStreamService
 import dk.cachet.carp.data.application.DataStreamsConfiguration
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamService.kt
@@ -21,7 +21,9 @@ class InMemoryDataStreamService : DataStreamService
         ExtractUniqueKeyMap( { configuration -> configuration.studyDeploymentId } )
         {
             studyDeploymentId ->
-                IllegalStateException( "Data streams for deployment with \"$studyDeploymentId\" have already been configured." )
+                IllegalStateException(
+                    "Data streams for deployment with \"$studyDeploymentId\" have already been configured."
+                )
         }
     private val stoppedStudyDeploymentIds: MutableSet<UUID> = mutableSetOf()
     private val dataStreams: MutableDataStreamBatch = MutableDataStreamBatch()

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethods.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethods.kt
@@ -11,11 +11,7 @@ import dk.cachet.carp.common.application.toTrilean
 import dk.cachet.carp.data.application.DataStreamId
 import dk.cachet.carp.data.application.DataStreamSequence
 import dk.cachet.carp.data.application.Measurement
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 import kotlin.reflect.KClass
 
 

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethodsTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/SerializerDerivedMethodsTest.kt
@@ -19,8 +19,7 @@ import dk.cachet.carp.data.application.stubDeploymentId
 import dk.cachet.carp.data.application.stubSequenceDeviceRoleName
 import dk.cachet.carp.data.application.stubSyncPoint
 import dk.cachet.carp.data.application.stubTriggerIds
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -108,7 +108,11 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * - [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device
      * @throws IllegalStateException when this deployment has stopped.
      */
-    suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
+    suspend fun registerDevice(
+        studyDeploymentId: UUID,
+        deviceRoleName: String,
+        registration: DeviceRegistration
+    ): StudyDeploymentStatus
 
     /**
      * Unregister the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
@@ -129,7 +133,10 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * - the device with [primaryDeviceRoleName] has not yet been registered
      * @throws IllegalStateException when the deployment for the requested primary device is not yet available.
      */
-    suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, primaryDeviceRoleName: String ): PrimaryDeviceDeployment
+    suspend fun getDeviceDeploymentFor(
+        studyDeploymentId: UUID,
+        primaryDeviceRoleName: String
+    ): PrimaryDeviceDeployment
 
     /**
      * Indicate to stakeholders in the study deployment with [studyDeploymentId]

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -9,8 +9,7 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
@@ -182,7 +182,10 @@ class DeploymentServiceHost(
      * - the device with [primaryDeviceRoleName] has not yet been registered
      * @throws IllegalStateException when the deployment for the requested primary device is not yet available.
      */
-    override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, primaryDeviceRoleName: String ): PrimaryDeviceDeployment
+    override suspend fun getDeviceDeploymentFor(
+        studyDeploymentId: UUID,
+        primaryDeviceRoleName: String
+    ): PrimaryDeviceDeployment
     {
         val deployment: StudyDeployment = repository.getStudyDeploymentOrThrowBy( studyDeploymentId )
         val device = getRegisteredPrimaryDevice( deployment, primaryDeviceRoleName )
@@ -254,15 +257,24 @@ class DeploymentServiceHost(
     private fun getRegistrableDevice( deployment: StudyDeployment, deviceRoleName: String ): RegistrableDevice
     {
         return deployment.registrableDevices.firstOrNull { it.device.roleName == deviceRoleName }
-            ?: throw IllegalArgumentException( "A device with the role name '$deviceRoleName' could not be found in the study deployment." )
+            ?: throw IllegalArgumentException(
+                "A device with the role name '$deviceRoleName' could not be found in the study deployment."
+            )
     }
 
-    private fun getRegisteredPrimaryDevice( deployment: StudyDeployment, primaryDeviceRoleName: String ): AnyPrimaryDeviceConfiguration
+    private fun getRegisteredPrimaryDevice(
+        deployment: StudyDeployment,
+        primaryDeviceRoleName: String
+    ): AnyPrimaryDeviceConfiguration
     {
-        val registeredDevice = deployment.registeredDevices.entries.firstOrNull { it.key.roleName == primaryDeviceRoleName }?.toPair()
-            ?: throw IllegalArgumentException( "The specified device role name is not part of this study deployment or is not yet registered." )
+        val registeredDevice = deployment.registeredDevices.keys.firstOrNull { it.roleName == primaryDeviceRoleName }
+            ?: throw IllegalArgumentException(
+                "The specified device role name is not part of this study deployment or is not yet registered."
+            )
 
-        return registeredDevice.first as? AnyPrimaryDeviceConfiguration
-            ?: throw IllegalArgumentException( "The specified device is not a primary device and therefore does not have a deployment configuration." )
+        return registeredDevice as? AnyPrimaryDeviceConfiguration
+            ?: throw IllegalArgumentException(
+                "The specified device is not a primary device and therefore does not have a deployment configuration."
+            )
     }
 }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeviceDeploymentStatus.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeviceDeploymentStatus.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.deployments.application
 
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
@@ -9,8 +9,7 @@ import dk.cachet.carp.common.application.services.DependentServices
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHost.kt
@@ -6,6 +6,7 @@ import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.data.input.InputDataTypeList
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
+import dk.cachet.carp.common.application.devices.isPrimary
 import dk.cachet.carp.common.application.services.ApplicationServiceEventBus
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
@@ -50,7 +51,7 @@ class ParticipationServiceHost(
 
             // Keep track of primary device registration changes.
             event { registrationChange: DeploymentService.Event.DeviceRegistrationChanged ->
-                if ( registrationChange.device !is AnyPrimaryDeviceConfiguration ) return@event
+                if ( !registrationChange.device.isPrimary() ) return@event
 
                 val group = participationRepository.getParticipantGroup( registrationChange.studyDeploymentId )
                 checkNotNull( group )

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/PrimaryDeviceDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/PrimaryDeviceDeployment.kt
@@ -14,7 +14,7 @@ import dk.cachet.carp.common.application.users.hasNoConflicts
 import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/StudyDeploymentStatus.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/StudyDeploymentStatus.kt
@@ -116,5 +116,7 @@ sealed class StudyDeploymentStatus
      */
     fun getDeviceStatus( deviceRoleName: String ): DeviceDeploymentStatus =
         deviceStatusList.firstOrNull { it.device.roleName == deviceRoleName }
-            ?: throw IllegalArgumentException( "The device with the given role name was not found in this study deployment." )
+            ?: throw IllegalArgumentException(
+                "The device with the given role name was not found in this study deployment."
+            )
 }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/StudyDeploymentStatus.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/StudyDeploymentStatus.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
 import dk.cachet.carp.deployments.application.users.ParticipantStatus
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/StudyDeploymentStatus.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/StudyDeploymentStatus.kt
@@ -20,6 +20,7 @@ sealed class StudyDeploymentStatus
     abstract val createdOn: Instant
 
     abstract val studyDeploymentId: UUID
+
     /**
      * The list of all devices part of this study deployment and their status.
      */

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/Validation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/Validation.kt
@@ -61,9 +61,15 @@ fun StudyProtocolSnapshot.throwIfInvalidPreregistrations(
     connectedDevicePreregistrations.forEach { (roleName, registration) ->
         val connectedDevice = connectedDevices.firstOrNull { it.roleName == roleName }
         requireNotNull( connectedDevice )
-            { "The device with role name \"$roleName\" for which a preregistration was defined isn't a connected device in the study protocol." }
+        {
+            "The device with role name \"$roleName\" for which a preregistration was defined " +
+            "isn't a connected device in the study protocol."
+        }
+
         val isInvalidRegistration = connectedDevice.isDefinitelyInvalidRegistration( registration )
         require( !isInvalidRegistration )
-            { "The preregistration for the connected device with role name \"$roleName\" is invalid." }
+        {
+            "The preregistration for the connected device with role name \"$roleName\" is invalid."
+        }
     }
 }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ActiveParticipationInvitation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ActiveParticipationInvitation.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.deployments.application.users
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/AssignedPrimaryDevice.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/AssignedPrimaryDevice.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.deployments.application.users
 
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.devices.DeviceRegistration
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ParticipantData.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ParticipantData.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.deployments.application.users
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.InputDataType
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ParticipantInvitation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ParticipantInvitation.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.deployments.application.users
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.application.users.AssignedTo
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ParticipantStatus.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/ParticipantStatus.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.deployments.application.users
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AssignedTo
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/Participation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/Participation.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.deployments.application.users
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AssignedTo
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/StudyInvitation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/StudyInvitation.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.deployments.application.users
 
 import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/RegistrableDevice.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/RegistrableDevice.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.deployments.domain
 
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.deployments.application.PrimaryDeviceDeployment
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.devices.DeviceRegistration
+import dk.cachet.carp.common.application.devices.isPrimary
 import dk.cachet.carp.common.application.tasks.getAllExpectedDataTypes
 import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.domain.AggregateRoot
@@ -274,14 +275,8 @@ class StudyDeployment private constructor(
             .plus( device ) // Device itself needs to be registered.
             .minus( alreadyRegistered )
         val mandatoryConnectedDevices =
-            if ( device is AnyPrimaryDeviceConfiguration )
-            {
-                protocol.getConnectedDevices( device ).filter { !it.isOptional }
-            }
-            else
-            {
-                emptyList()
-            }
+            if ( device.isPrimary() ) protocol.getConnectedDevices( device ).filter { !it.isOptional }
+            else emptyList()
         val toRegisterBeforeDeployment = toRegisterToObtainDeployment
             // Primary devices require non-optional connected devices to be registered.
             .plus( mandatoryConnectedDevices )

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -38,7 +38,10 @@ class StudyDeployment private constructor(
 {
     sealed class Event : DomainEvent
     {
-        data class DeviceRegistered( val device: AnyDeviceConfiguration, val registration: DeviceRegistration ) : Event()
+        data class DeviceRegistered(
+            val device: AnyDeviceConfiguration,
+            val registration: DeviceRegistration
+        ) : Event()
         data class DeviceUnregistered( val device: AnyDeviceConfiguration ) : Event()
         data class DeviceDeployed( val device: AnyPrimaryDeviceConfiguration ) : Event()
         data class Started( val startedOn: Instant ) : Event()
@@ -86,7 +89,9 @@ class StudyDeployment private constructor(
             // Replay device registration history.
             snapshot.deviceRegistrationHistory.forEach { (roleName, registrations) ->
                 val device = deployment.registrableDevices.map { it.device }.firstOrNull { it.roleName == roleName }
-                    ?: throw IllegalArgumentException( "Can't find registered device with role name '$roleName' in snapshot." )
+                    ?: throw IllegalArgumentException(
+                        "Can't find registered device with role name '$roleName' in snapshot."
+                    )
                 registrations.forEachIndexed { index, registration ->
                     val isNotFirstOrLast = index in 1 until registrations.size
                     if ( isNotFirstOrLast ) deployment.unregisterDevice( device )
@@ -100,14 +105,18 @@ class StudyDeployment private constructor(
             // Add deployed devices.
             snapshot.deployedDevices.forEach { roleName ->
                 val deployedDevice = deployment.protocolSnapshot.primaryDevices.firstOrNull { it.roleName == roleName }
-                    ?: throw IllegalArgumentException( "Can't find deployed device with role name '$roleName' in snapshot." )
+                    ?: throw IllegalArgumentException(
+                        "Can't find deployed device with role name '$roleName' in snapshot."
+                    )
                 deployment._deployedDevices.add( deployedDevice )
             }
 
             // Add invalidated deployed devices.
             val invalidatedDevices = snapshot.invalidatedDeployedDevices.map { invalidatedRoleName ->
                 deployment.protocolSnapshot.primaryDevices.firstOrNull { it.roleName == invalidatedRoleName }
-                    ?: throw IllegalArgumentException( "Can't find deployed device with role name '$invalidatedRoleName' in snapshot." )
+                    ?: throw IllegalArgumentException(
+                        "Can't find deployed device with role name '$invalidatedRoleName' in snapshot."
+                    )
             }
             deployment._invalidatedDeployedDevices.addAll( invalidatedDevices )
 
@@ -168,7 +177,8 @@ class StudyDeployment private constructor(
     val deviceRegistrationHistory: Map<AnyDeviceConfiguration, List<DeviceRegistration>>
         get() = _deviceRegistrationHistory
 
-    private val _deviceRegistrationHistory: MutableMap<AnyDeviceConfiguration, MutableList<DeviceRegistration>> = mutableMapOf()
+    private val _deviceRegistrationHistory: MutableMap<AnyDeviceConfiguration, MutableList<DeviceRegistration>> =
+        mutableMapOf()
 
     /**
      * The set of devices which have been deployed correctly.
@@ -237,10 +247,14 @@ class StudyDeployment private constructor(
 
         val deviceList = devices.values.toList()
         return when {
-            isStopped -> StudyDeploymentStatus.Stopped( createdOn, id, deviceList, participantList, startedOn, stoppedOn!! )
-            allRequiredDevicesDeployed -> StudyDeploymentStatus.Running( createdOn, id, deviceList, participantList, startedOn!! )
-            anyRegistration -> StudyDeploymentStatus.DeployingDevices( createdOn, id, deviceList, participantList, startedOn )
-            else -> StudyDeploymentStatus.Invited( createdOn, id, deviceList, participantList, startedOn )
+            isStopped ->
+                StudyDeploymentStatus.Stopped( createdOn, id, deviceList, participantList, startedOn, stoppedOn!! )
+            allRequiredDevicesDeployed ->
+                StudyDeploymentStatus.Running( createdOn, id, deviceList, participantList, startedOn!! )
+            anyRegistration ->
+                StudyDeploymentStatus.DeployingDevices( createdOn, id, deviceList, participantList, startedOn )
+            else ->
+                StudyDeploymentStatus.Invited( createdOn, id, deviceList, participantList, startedOn )
         }
     }
 
@@ -260,8 +274,14 @@ class StudyDeployment private constructor(
             .plus( device ) // Device itself needs to be registered.
             .minus( alreadyRegistered )
         val mandatoryConnectedDevices =
-            if ( device is AnyPrimaryDeviceConfiguration ) protocol.getConnectedDevices( device ).filter { !it.isOptional }
-            else emptyList()
+            if ( device is AnyPrimaryDeviceConfiguration )
+            {
+                protocol.getConnectedDevices( device ).filter { !it.isOptional }
+            }
+            else
+            {
+                emptyList()
+            }
         val toRegisterBeforeDeployment = toRegisterToObtainDeployment
             // Primary devices require non-optional connected devices to be registered.
             .plus( mandatoryConnectedDevices )
@@ -271,10 +291,14 @@ class StudyDeployment private constructor(
         val beforeDeployment = toRegisterBeforeDeployment.map { it.roleName }.toSet()
         return when
         {
-            needsRedeployment -> DeviceDeploymentStatus.NeedsRedeployment( device, toObtainDeployment, beforeDeployment )
-            isDeployed -> DeviceDeploymentStatus.Deployed( device )
-            isRegistered -> DeviceDeploymentStatus.Registered( device, canBeDeployed, toObtainDeployment, beforeDeployment )
-            else -> DeviceDeploymentStatus.Unregistered( device, canBeDeployed, toObtainDeployment, beforeDeployment )
+            needsRedeployment ->
+                DeviceDeploymentStatus.NeedsRedeployment( device, toObtainDeployment, beforeDeployment )
+            isDeployed ->
+                DeviceDeploymentStatus.Deployed( device )
+            isRegistered ->
+                DeviceDeploymentStatus.Registered( device, canBeDeployed, toObtainDeployment, beforeDeployment )
+            else ->
+                DeviceDeploymentStatus.Unregistered( device, canBeDeployed, toObtainDeployment, beforeDeployment )
         }
     }
 
@@ -320,8 +344,13 @@ class StudyDeployment private constructor(
             val isSameId = it.value.deviceId == registration.deviceId
             val otherDevice = it.key
             val areUnknownDevices = device is UnknownPolymorphicWrapper && otherDevice is UnknownPolymorphicWrapper
-            val matchingUnknownDevices: Boolean by lazy { (device as UnknownPolymorphicWrapper).className == (otherDevice as UnknownPolymorphicWrapper).className }
-            isSameId && ( (!areUnknownDevices && otherDevice::class == device::class) || (areUnknownDevices && matchingUnknownDevices) )
+            val matchingUnknownDevices: Boolean by lazy {
+                (device as UnknownPolymorphicWrapper).className == (otherDevice as UnknownPolymorphicWrapper).className
+            }
+            isSameId && (
+                (!areUnknownDevices && otherDevice::class == device::class) ||
+                (areUnknownDevices && matchingUnknownDevices)
+            )
         }
         require( isUnique )
         {
@@ -387,13 +416,16 @@ class StudyDeployment private constructor(
     fun getDeviceDeploymentFor( device: AnyPrimaryDeviceConfiguration ): PrimaryDeviceDeployment
     {
         // Verify whether the specified device is part of the protocol of this deployment.
-        require( device in protocolSnapshot.primaryDevices ) { "The specified primary device is not part of the protocol of this deployment." }
+        require( device in protocolSnapshot.primaryDevices )
+            { "The specified primary device is not part of the protocol of this deployment." }
 
         // Verify whether the specified device is ready to be deployed.
         val canDeploy = getDeviceStatus( device ).canObtainDeviceDeployment
-        check( canDeploy ) { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
+        check( canDeploy )
+            { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
 
-        val configuration: DeviceRegistration = _registeredDevices[ device ]!! // Must be non-null, otherwise canObtainDeviceDeployment would fail.
+        // Configuration must be non-null, otherwise canObtainDeviceDeployment would fail.
+        val configuration: DeviceRegistration = _registeredDevices[ device ]!!
 
         // Determine which devices this device needs to connect to and retrieve configuration for preregistered devices.
         val connectedDevices: Set<AnyDeviceConfiguration> = protocol.getConnectedDevices( device ).toSet()

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentSnapshot.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.deployments.application.users.ParticipantStatus
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/AccountParticipation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/AccountParticipation.kt
@@ -4,7 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.Participation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroup.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroup.kt
@@ -160,7 +160,9 @@ class ParticipantGroup private constructor(
      */
     fun getAssignedPrimaryDevice( roleName: String ) =
         assignedPrimaryDevices.firstOrNull { it.device.roleName == roleName }
-            ?: throw IllegalArgumentException( "There is no assigned device with role name \"$roleName\" for this participant group." )
+            ?: throw IllegalArgumentException(
+                "There is no assigned device with role name \"$roleName\" for this participant group."
+            )
 
     /**
      * Update the device [registration] for the given assigned [primaryDevice].

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupService.kt
@@ -15,7 +15,9 @@ class ParticipantGroupService( val accountService: AccountService )
      *
      * @throws IllegalArgumentException when the invitations do not match the requirements from the protocol.
      */
-    suspend fun createAndInviteParticipantGroup( createdDeployment: DeploymentService.Event.StudyDeploymentCreated ): ParticipantGroup
+    suspend fun createAndInviteParticipantGroup(
+        createdDeployment: DeploymentService.Event.StudyDeploymentCreated
+    ): ParticipantGroup
     {
         // Verify whether the participant group matches the requirements of the protocol.
         val studyDeploymentId = createdDeployment.studyDeploymentId

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupSnapshot.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupSnapshot.kt
@@ -8,7 +8,7 @@ import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.deployments.application.users.AssignedPrimaryDevice
 import dk.cachet.carp.deployments.application.users.ParticipantData
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipationRepository.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipationRepository.kt
@@ -22,7 +22,9 @@ interface ParticipationRepository
      */
     suspend fun getParticipantGroupOrThrowBy( studyDeploymentId: UUID ): ParticipantGroup =
         getParticipantGroup( studyDeploymentId )
-            ?: throw IllegalArgumentException( "A participant group for the study deployment with ID '$studyDeploymentId' does not exist." )
+            ?: throw IllegalArgumentException(
+                "A participant group for the study deployment with ID '$studyDeploymentId' does not exist."
+            )
 
     /**
      * Return all [ParticipantGroup]s matching the specified [studyDeploymentIds].
@@ -38,7 +40,8 @@ interface ParticipationRepository
     suspend fun getParticipantGroupListOrThrow( studyDeploymentIds: Set<UUID> ): List<ParticipantGroup>
     {
         val groups = getParticipantGroupList( studyDeploymentIds )
-        require( studyDeploymentIds.size == groups.size ) { "A study deployment ID has been passed for which no participant group exists." }
+        require( studyDeploymentIds.size == groups.size )
+            { "A study deployment ID has been passed for which no participant group exists." }
 
         return groups
     }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequest.kt
@@ -11,10 +11,7 @@ import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/InMemoryAccountService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/InMemoryAccountService.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployments.infrastructure
 
+import dk.cachet.carp.common.application.DefaultUUIDFactory
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.UUIDFactory
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
@@ -13,7 +14,7 @@ import dk.cachet.carp.deployments.domain.users.AccountService
 /**
  * An [AccountService] which holds accounts in memory as long as the instance is held in memory.
  */
-class InMemoryAccountService( val uuidFactory: UUIDFactory = UUID.Companion ) : AccountService
+class InMemoryAccountService( val uuidFactory: UUIDFactory = DefaultUUIDFactory ) : AccountService
 {
     private val accounts: MutableList<Account> = mutableListOf()
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceRequest.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceRequest.kt
@@ -9,10 +9,7 @@ import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.deployments.application.ParticipationService
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceTest.kt
@@ -105,7 +105,7 @@ interface ParticipationServiceTest
         assertEquals( participantRoleNames, participantData.roles.map { it.roleName }.toSet() )
         assertTrue(
             participantData.roles.all {
-                it.data.keys.firstOrNull() == CarpInputDataTypes.SEX && it.data.values.firstOrNull() == null
+                it.data.keys.single() == CarpInputDataTypes.SEX && it.data.values.single() == null
             }
         )
     }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ActiveParticipationInvitationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ActiveParticipationInvitationTest.kt
@@ -8,8 +8,7 @@ import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitatio
 import dk.cachet.carp.deployments.application.users.AssignedPrimaryDevice
 import dk.cachet.carp.deployments.application.users.Participation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipantDataTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipantDataTest.kt
@@ -8,8 +8,7 @@ import dk.cachet.carp.common.application.data.input.Sex
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.deployments.application.users.ParticipantData
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationTest.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.deployments.infrastructure
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.users.Participation
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/PrimaryDeviceDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/PrimaryDeviceDeploymentTest.kt
@@ -11,8 +11,7 @@ import dk.cachet.carp.common.infrastructure.test.StubTaskConfiguration
 import dk.cachet.carp.common.infrastructure.test.StubTriggerConfiguration
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.deployments.application.PrimaryDeviceDeployment
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
@@ -12,9 +12,7 @@ import dk.cachet.carp.deployments.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployments.domain.createComplexDeployment
 import dk.cachet.carp.deployments.domain.studyDeploymentFor
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
@@ -16,9 +16,7 @@ import dk.cachet.carp.deployments.domain.studyDeploymentFor
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSinglePrimaryWithConnectedDeviceProtocol
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentTest.kt
@@ -15,9 +15,7 @@ import dk.cachet.carp.deployments.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployments.domain.studyDeploymentFor
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyInvitationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyInvitationTest.kt
@@ -2,8 +2,7 @@ package dk.cachet.carp.deployments.infrastructure
 
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.users.StudyInvitation
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.detekt/src/main/kotlin/dk/cachet/carp/detekt/extensions/rules/CurlyBracesOnSeparateLine.kt
+++ b/carp.detekt/src/main/kotlin/dk/cachet/carp/detekt/extensions/rules/CurlyBracesOnSeparateLine.kt
@@ -32,7 +32,8 @@ class CurlyBracesOnSeparateLine( config: Config = Config.empty ) : Rule( config 
         javaClass.simpleName,
         Severity.Style,
         "Curly braces of blocks need to be placed on separate lines (except for trailing lambda arguments), " +
-        "aligned with the start of the definition the block is associated with (e.g., class, function, object literal, or return).",
+        "aligned with the start of the definition the block is associated with " +
+        "(e.g., class, function, object literal, or return).",
         Debt.FIVE_MINS
     )
 

--- a/carp.detekt/src/main/kotlin/dk/cachet/carp/detekt/extensions/rules/SpacingInParentheses.kt
+++ b/carp.detekt/src/main/kotlin/dk/cachet/carp/detekt/extensions/rules/SpacingInParentheses.kt
@@ -42,7 +42,8 @@ class SpacingInParentheses( config: Config = Config.empty ) : Rule( config )
             val noSpaces = accessor.text.startsWith( "get()" )
             if ( !noSpaces )
             {
-                report( CodeSmell( issue, Entity.from( accessor ), "Get accessors should not contain spaces in the parentheses." ) )
+                val message = "Get accessors should not contain spaces in the parentheses."
+                report( CodeSmell( issue, Entity.from( accessor ), message ) )
             }
         }
     }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
@@ -6,8 +6,7 @@ import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.tasks.CustomProtocolTask
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHost.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.application
 
+import dk.cachet.carp.common.application.DefaultUUIDFactory
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.UUIDFactory
 import dk.cachet.carp.common.application.devices.CustomProtocolDevice
@@ -14,7 +15,7 @@ import kotlinx.datetime.Clock
  * to create [StudyProtocolSnapshot]'s according to predefined templates.
 */
 class ProtocolFactoryServiceHost(
-    val uuidFactory: UUIDFactory = UUID.Companion,
+    val uuidFactory: UUIDFactory = DefaultUUIDFactory,
     val clock: Clock = Clock.System
 ) : ProtocolFactoryService
 {

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -8,8 +8,7 @@ import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import kotlinx.datetime.Clock
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolVersion.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolVersion.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.protocols.application
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
@@ -70,8 +70,8 @@ data class StudyProtocolSnapshot(
                 triggers = triggers,
                 taskControls = triggers
                     .flatMap { trigger -> protocol.getTaskControls( trigger.value ).map { trigger to it } }
-                    .map { (trigger, control) ->
-                        TaskControl( trigger.key, control.task.name, control.destinationDevice.roleName, control.control )
+                    .map { (trigger, tc) ->
+                        TaskControl( trigger.key, tc.task.name, tc.destinationDevice.roleName, tc.control )
                     }
                     .toSet(),
                 participantRoles = protocol.participantRoles.toSet(),
@@ -84,7 +84,10 @@ data class StudyProtocolSnapshot(
             )
         }
 
-        private fun getConnections( protocol: StudyProtocol, primaryDevice: AnyPrimaryDeviceConfiguration ): Iterable<DeviceConnection>
+        private fun getConnections(
+            protocol: StudyProtocol,
+            primaryDevice: AnyPrimaryDeviceConfiguration
+        ): Iterable<DeviceConnection>
         {
             val connections: MutableList<DeviceConnection> = mutableListOf()
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
@@ -14,7 +14,7 @@ import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.protocols.application
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
+import dk.cachet.carp.common.application.devices.isPrimary
 import dk.cachet.carp.common.application.tasks.TaskConfiguration
 import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.application.triggers.TriggerConfiguration
@@ -91,12 +92,9 @@ data class StudyProtocolSnapshot(
         {
             val connections: MutableList<DeviceConnection> = mutableListOf()
 
-            protocol.getConnectedDevices( primaryDevice ).forEach {
-                connections.add( DeviceConnection( it.roleName, primaryDevice.roleName ) )
-                if ( it is AnyPrimaryDeviceConfiguration )
-                {
-                    connections.addAll( getConnections( protocol, it ) )
-                }
+            protocol.getConnectedDevices( primaryDevice ).forEach { device ->
+                connections.add( DeviceConnection( device.roleName, primaryDevice.roleName ) )
+                if ( device.isPrimary() ) connections.addAll( getConnections( protocol, device ) )
             }
 
             return connections

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -113,7 +113,10 @@ class StudyProtocol(
             {
                 require( triggerIds.first() == 0 && triggerIds.last() == triggerIds.size - 1 )
                     { "Triggers should be given sequential IDs starting with 0." }
-                triggerIds.map { protocol.addTrigger( snapshot.triggers[ it ]!! ) }
+                triggerIds.map {
+                    val trigger = checkNotNull( snapshot.triggers[ it ] )
+                    protocol.addTrigger( trigger )
+                }
             }
 
             // Add task controls.
@@ -243,10 +246,8 @@ class StudyProtocol(
         val device: AnyDeviceConfiguration = deviceConfiguration.devices.firstOrNull { it.roleName == trigger.sourceDeviceRoleName }
             ?: throw IllegalArgumentException( "The passed trigger does not belong to any device specified in this study protocol." )
 
-        if ( trigger.requiresPrimaryDevice && device !is AnyPrimaryDeviceConfiguration )
-        {
-            throw IllegalArgumentException( "The passed trigger cannot be initiated by the specified device since it is not a primary device." )
-        }
+        require( !trigger.requiresPrimaryDevice || device is AnyPrimaryDeviceConfiguration )
+            { "The passed trigger cannot be initiated by the specified device since it is not a primary device." }
 
         val isAdded = _triggers.add( trigger )
         if ( isAdded )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -5,6 +5,7 @@ package dk.cachet.carp.protocols.domain
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
+import dk.cachet.carp.common.application.devices.isPrimary
 import dk.cachet.carp.common.application.tasks.TaskConfiguration
 import dk.cachet.carp.common.application.triggers.TaskControl.Control
 import dk.cachet.carp.common.application.triggers.TriggerConfiguration
@@ -259,7 +260,7 @@ class StudyProtocol(
                 "The passed trigger does not belong to any device specified in this study protocol."
             )
 
-        require( !trigger.requiresPrimaryDevice || device is AnyPrimaryDeviceConfiguration )
+        require( !trigger.requiresPrimaryDevice || device.isPrimary() )
             { "The passed trigger cannot be initiated by the specified device since it is not a primary device." }
 
         val isAdded = _triggers.add( trigger )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -1,5 +1,3 @@
-@file:Suppress( "WildcardImport" )
-
 package dk.cachet.carp.protocols.domain
 
 import dk.cachet.carp.common.application.UUID

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -29,7 +29,8 @@ import kotlinx.datetime.Instant
  * A description of how a study is to be executed, defining the type(s) of primary device(s) ([AnyPrimaryDeviceConfiguration]) responsible for aggregating data,
  * the optional devices ([AnyDeviceConfiguration]) connected to them, and the [TriggerConfiguration]'s which lead to data collection on said devices.
  */
-@Suppress( "TooManyFunctions" ) // TODO: some of the device and task configuration methods are overridden solely to add events. Can this be refactored?
+// TODO: some of the device and task configuration methods are overridden solely to add events. Can this be refactored?
+@Suppress( "TooManyFunctions" )
 class StudyProtocol(
     /**
      * The entity (e.g., person or group) that created this [StudyProtocol].
@@ -82,25 +83,26 @@ class StudyProtocol(
         @Suppress( "ComplexMethod" )
         fun fromSnapshot( snapshot: StudyProtocolSnapshot ): StudyProtocol
         {
-            val protocol = StudyProtocol(
-                snapshot.ownerId,
-                snapshot.name,
-                snapshot.description,
-                snapshot.id,
-                snapshot.createdOn
-            )
+            val protocol = with( snapshot ) { StudyProtocol( ownerId, name, description, id, createdOn ) }
             protocol.applicationData = snapshot.applicationData
 
             // Add primary devices.
             snapshot.primaryDevices.forEach { protocol.addPrimaryDevice( it ) }
 
             // Add connected devices.
-            val allDevices: List<AnyDeviceConfiguration> = snapshot.connectedDevices.plus( snapshot.primaryDevices ).toList()
+            val allDevices: List<AnyDeviceConfiguration> =
+                snapshot.connectedDevices.plus( snapshot.primaryDevices ).toList()
             snapshot.connections.forEach { c ->
-                val primary: AnyPrimaryDeviceConfiguration = allDevices.filterIsInstance<AnyPrimaryDeviceConfiguration>().firstOrNull { it.roleName == c.connectedToRoleName }
-                    ?: throw IllegalArgumentException( "Can't find primary device with role name '${c.connectedToRoleName}' in snapshot." )
+                val primary: AnyPrimaryDeviceConfiguration = allDevices
+                    .filterIsInstance<AnyPrimaryDeviceConfiguration>()
+                    .firstOrNull { it.roleName == c.connectedToRoleName }
+                        ?: throw IllegalArgumentException(
+                            "Can't find primary device with role name '${c.connectedToRoleName}' in snapshot."
+                        )
                 val connected: AnyDeviceConfiguration = allDevices.firstOrNull { it.roleName == c.roleName }
-                    ?: throw IllegalArgumentException( "Can't find connected device with role name '${c.roleName}' in snapshot." )
+                    ?: throw IllegalArgumentException(
+                        "Can't find connected device with role name '${c.roleName}' in snapshot."
+                    )
                 protocol.addConnectedDevice( connected, primary )
             }
 
@@ -122,11 +124,17 @@ class StudyProtocol(
             // Add task controls.
             snapshot.taskControls.forEach { control ->
                 val triggerMatch = snapshot.triggers.entries.singleOrNull { it.key == control.triggerId }
-                    ?: throw IllegalArgumentException( "Can't find trigger with id '${control.triggerId}' in snapshot." )
+                    ?: throw IllegalArgumentException(
+                        "Can't find trigger with id '${control.triggerId}' in snapshot."
+                    )
                 val task: TaskConfiguration<*> = protocol.tasks.singleOrNull { it.name == control.taskName }
-                    ?: throw IllegalArgumentException( "Can't find task with name '${control.taskName}' in snapshot." )
-                val device: AnyDeviceConfiguration = protocol.devices.singleOrNull { it.roleName == control.destinationDeviceRoleName }
-                    ?: throw IllegalArgumentException( "Can't find device with role name '${control.destinationDeviceRoleName}' in snapshot." )
+                    ?: throw IllegalArgumentException(
+                        "Can't find task with name '${control.taskName}' in snapshot."
+                    )
+                val device = protocol.devices.singleOrNull { it.roleName == control.destinationDeviceRoleName }
+                    ?: throw IllegalArgumentException(
+                        "Can't find device with role name '${control.destinationDeviceRoleName}' in snapshot."
+                    )
                 protocol.addTaskControl( triggerMatch.value, task, device, control.control )
             }
 
@@ -212,8 +220,11 @@ class StudyProtocol(
      *   - [device] contains invalid default sampling configurations
      * @return True if the [device] has been added; false if it is already connected to the specified [primaryDevice].
      */
-    override fun addConnectedDevice( device: AnyDeviceConfiguration, primaryDevice: AnyPrimaryDeviceConfiguration ): Boolean =
-        super.addConnectedDevice( device, primaryDevice )
+    override fun addConnectedDevice(
+        device: AnyDeviceConfiguration,
+        primaryDevice: AnyPrimaryDeviceConfiguration
+    ): Boolean = super
+        .addConnectedDevice( device, primaryDevice )
         .eventIf( true ) { Event.ConnectedDeviceAdded( device, primaryDevice ) }
 
     /**
@@ -243,8 +254,10 @@ class StudyProtocol(
      */
     fun addTrigger( trigger: TriggerConfiguration<*> ): TriggerWithId
     {
-        val device: AnyDeviceConfiguration = deviceConfiguration.devices.firstOrNull { it.roleName == trigger.sourceDeviceRoleName }
-            ?: throw IllegalArgumentException( "The passed trigger does not belong to any device specified in this study protocol." )
+        val device = deviceConfiguration.devices.firstOrNull { it.roleName == trigger.sourceDeviceRoleName }
+            ?: throw IllegalArgumentException(
+                "The passed trigger does not belong to any device specified in this study protocol."
+            )
 
         require( !trigger.requiresPrimaryDevice || device is AnyPrimaryDeviceConfiguration )
             { "The passed trigger cannot be initiated by the specified device since it is not a primary device." }
@@ -453,8 +466,10 @@ class StudyProtocol(
      */
     fun changeDeviceAssignment( device: AnyPrimaryDeviceConfiguration, assignedTo: AssignedTo ): Boolean
     {
-        require( _deviceAssignments.containsKey( device ) ) { "The device configuration is not part of this protocol." }
-        require( isValidAssignment( assignedTo ) ) { "One of the assigned participant roles is not part of this protocol." }
+        require( _deviceAssignments.containsKey( device ) )
+            { "The device configuration is not part of this protocol." }
+        require( isValidAssignment( assignedTo ) )
+            { "One of the assigned participant roles is not part of this protocol." }
 
         val isChanged = _deviceAssignments.put( device, assignedTo ) != assignedTo
         if ( isChanged ) event( Event.DeviceAssignmentChanged( device, assignedTo ) )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -54,9 +54,10 @@ interface StudyProtocolRepository
      *
      * @throws IllegalArgumentException when the requested protocol is not found.
      */
-    suspend fun getByOrThrow( id: UUID, versionTag: String? = null ): StudyProtocol =
-        getBy( id, versionTag )
-            ?: throw IllegalArgumentException( "A protocol with ID \"$id\" and the specified version tag does not exist." )
+    suspend fun getByOrThrow( id: UUID, versionTag: String? = null ): StudyProtocol = getBy( id, versionTag )
+        ?: throw IllegalArgumentException(
+            "A protocol with ID \"$id\" and the specified version tag does not exist."
+        )
 
     /**
      * Find all [StudyProtocol]'s owned by the owner with [ownerId], or an empty sequence if none are found.

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyProtocolDeviceConfiguration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyProtocolDeviceConfiguration.kt
@@ -12,7 +12,9 @@ import dk.cachet.carp.common.domain.ExtractUniqueKeyMap
  * Role names of added [DeviceConfiguration]s should be unique.
  */
 @Suppress( "Immutable", "DataClass" )
-internal class EmptyProtocolDeviceConfiguration : AbstractMap<String, AnyDeviceConfiguration>(), ProtocolDeviceConfiguration
+internal class EmptyProtocolDeviceConfiguration :
+    AbstractMap<String, AnyDeviceConfiguration>(),
+    ProtocolDeviceConfiguration
 {
     private val _devices: ExtractUniqueKeyMap<String, AnyDeviceConfiguration> =
         ExtractUniqueKeyMap( { device -> device.roleName } )
@@ -42,7 +44,10 @@ internal class EmptyProtocolDeviceConfiguration : AbstractMap<String, AnyDeviceC
         return isNewDevice
     }
 
-    override fun addConnectedDevice( device: AnyDeviceConfiguration, primaryDevice: AnyPrimaryDeviceConfiguration ): Boolean
+    override fun addConnectedDevice(
+        device: AnyDeviceConfiguration,
+        primaryDevice: AnyPrimaryDeviceConfiguration
+    ): Boolean
     {
         verifySamplingConfigurations( device )
         verifyPrimaryDevice( primaryDevice )
@@ -56,7 +61,10 @@ internal class EmptyProtocolDeviceConfiguration : AbstractMap<String, AnyDeviceC
             .add( device )
     }
 
-    override fun getConnectedDevices( primaryDevice: AnyPrimaryDeviceConfiguration, includeChainedDevices: Boolean ): Iterable<AnyDeviceConfiguration>
+    override fun getConnectedDevices(
+        primaryDevice: AnyPrimaryDeviceConfiguration,
+        includeChainedDevices: Boolean
+    ): Iterable<AnyDeviceConfiguration>
     {
         verifyPrimaryDevice( primaryDevice )
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/deployment/UnexpectedMeasuresWarning.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/deployment/UnexpectedMeasuresWarning.kt
@@ -19,8 +19,9 @@ class UnexpectedMeasuresWarning internal constructor() : DeploymentWarning
     data class UnexpectedMeasure( val device: AnyDeviceConfiguration, val measure: Measure )
 
     override val description: String =
-        "The study protocol contains measures that are requested on a device for which the requested data type is not expected." +
-        "This is allowed, but requires the client implementation to have corresponding support to handle this unexpected data type."
+        "The study protocol contains measures that are requested on a device " +
+        "for which the requested data type isn't expected. This is allowed, but " +
+        "requires the client implementation to have corresponding support to handle this unexpected data type."
 
 
     override fun isIssuePresent( protocol: StudyProtocol ): Boolean = getUnexpectedMeasures( protocol ).any()

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/deployment/UnusedDevicesWarning.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/deployment/UnusedDevicesWarning.kt
@@ -13,7 +13,8 @@ import dk.cachet.carp.protocols.domain.StudyProtocol
 class UnusedDevicesWarning internal constructor() : DeploymentWarning
 {
     override val description =
-        "The study protocol contains devices which are never used as the source or target of triggers, or to relay data (primary device). " +
+        "The study protocol contains devices which are never used as the source or target of triggers, " +
+        "or to relay data (primary device). " +
         "These devices thus serve no purpose as part of the specified study protocol."
 
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/deployment/UseCompositeTaskWarning.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/deployment/UseCompositeTaskWarning.kt
@@ -25,7 +25,8 @@ class UseCompositeTaskWarning internal constructor() : DeploymentWarning
 
     override val description: String =
         "The study protocol contains triggers which send multiple tasks to a single device. " +
-        "It is recommended to model this as one composite task instead, for clarity and to circumvent potential concurrency issues."
+        "It is recommended to model this as one composite task instead, " +
+        "for clarity and to circumvent potential concurrency issues."
 
 
     override fun isIssuePresent( protocol: StudyProtocol ): Boolean = getOverlappingTasks( protocol ).any()

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepository.kt
@@ -125,5 +125,7 @@ class InMemoryStudyProtocolRepository : StudyProtocolRepository
         ?: throw IllegalArgumentException( "The specified protocol is not stored in this repository" )
 
     private fun MutableMap<ProtocolVersion, StudyProtocolSnapshot>.getLatest() =
-        this.keys.last() // Versions are stored in order added. Adding versions quickly (e.g., in tests) can result in same dates.
+        // Versions are stored in order added.
+        // Adding versions quickly (e.g., in tests) can result in same dates.
+        this.keys.last()
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequest.kt
@@ -6,10 +6,7 @@ import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.protocols.application.ProtocolFactoryService
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
@@ -36,8 +36,10 @@ sealed class ProtocolServiceRequest<out TReturn> : ApplicationServiceRequest<Pro
     }
 
     @Serializable
-    data class AddVersion( val protocol: StudyProtocolSnapshot, val versionTag: String = Clock.System.now().toString() ) :
-        ProtocolServiceRequest<Unit>()
+    data class AddVersion(
+        val protocol: StudyProtocolSnapshot,
+        val versionTag: String = Clock.System.now().toString()
+    ) : ProtocolServiceRequest<Unit>()
     {
         override fun getResponseSerializer() = serializer<Unit>()
         override suspend fun invokeOn( service: ProtocolService ) = service.addVersion( protocol, versionTag )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
@@ -9,10 +9,7 @@ import dk.cachet.carp.protocols.application.ProtocolService
 import dk.cachet.carp.protocols.application.ProtocolVersion
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Clock
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolFactoryServiceApiMigrator.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolFactoryServiceApiMigrator.kt
@@ -7,7 +7,7 @@ import dk.cachet.carp.common.infrastructure.versioning.Major1Minor0To1Migration
 import dk.cachet.carp.common.infrastructure.versioning.getType
 import dk.cachet.carp.protocols.application.ProtocolFactoryService
 import dk.cachet.carp.protocols.infrastructure.ProtocolFactoryServiceRequest
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.*
 
 
 private val major1Minor0To1Migration =

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolServiceApiMigrator.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolServiceApiMigrator.kt
@@ -7,8 +7,7 @@ import dk.cachet.carp.common.infrastructure.versioning.Major1Minor0To1Migration
 import dk.cachet.carp.common.infrastructure.versioning.getType
 import dk.cachet.carp.protocols.application.ProtocolService
 import dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.*
 
 
 private val major1Minor0To1Migration =

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
@@ -14,7 +14,7 @@ import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.start
 import dk.cachet.carp.protocols.domain.within
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/configuration/ProtocolParticipantConfigurationTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/configuration/ProtocolParticipantConfigurationTest.kt
@@ -7,8 +7,7 @@ import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.common.application.users.ParticipantRole
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolVersionTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolVersionTest.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.protocols.infrastructure
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.protocols.application.ProtocolVersion
 import kotlinx.datetime.Clock
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
@@ -54,7 +54,7 @@ class StudyProtocolSnapshotTest :
         assertEquals( 1, parsed.tasks.filterIsInstance<CustomTaskConfiguration>().count() )
         val allMeasures = parsed.tasks.flatMap{ t -> t.measures }
         assertEquals( 2, allMeasures.count() )
-        assertEquals( 1, parsed.triggers.filter { t -> t.value is CustomTriggerConfiguration }.count() )
+        assertEquals( 1, parsed.triggers.count { t -> t.value is CustomTriggerConfiguration } )
     }
 
     @ExperimentalSerializationApi

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
@@ -21,9 +21,7 @@ import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.start
 import dk.cachet.carp.protocols.infrastructure.test.createComplexProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -9,8 +9,7 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.application
 
+import dk.cachet.carp.common.application.DefaultUUIDFactory
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.UUIDFactory
@@ -18,7 +19,7 @@ class RecruitmentServiceHost(
     private val participantRepository: ParticipantRepository,
     private val deploymentService: DeploymentService,
     private val eventBus: ApplicationServiceEventBus<RecruitmentService, RecruitmentService.Event>,
-    private val uuidFactory: UUIDFactory = UUID.Companion,
+    private val uuidFactory: UUIDFactory = DefaultUUIDFactory,
     private val clock: Clock = Clock.System
 ) : RecruitmentService
 {

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -108,7 +108,10 @@ class RecruitmentServiceHost(
      *  - not all necessary participant roles part of the study have been assigned a participant
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
-    override suspend fun inviteNewParticipantGroup( studyId: UUID, group: Set<AssignedParticipantRoles> ): ParticipantGroupStatus
+    override suspend fun inviteNewParticipantGroup(
+        studyId: UUID,
+        group: Set<AssignedParticipantRoles>
+    ): ParticipantGroupStatus
     {
         val recruitment = getRecruitmentOrThrow( studyId )
         val (protocol, invitations) = recruitment.createInvitations( group )
@@ -183,6 +186,7 @@ class RecruitmentServiceHost(
         return recruitment
     }
 
-    private suspend fun getRecruitmentOrThrow( studyId: UUID ): Recruitment = participantRepository.getRecruitment( studyId )
-        ?: throw IllegalArgumentException( "Study with ID \"$studyId\" not found." )
+    private suspend fun getRecruitmentOrThrow( studyId: UUID ): Recruitment =
+        participantRepository.getRecruitment( studyId )
+            ?: throw IllegalArgumentException( "Study with ID \"$studyId\" not found." )
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyDetails.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyDetails.kt
@@ -4,7 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -6,8 +6,7 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.application
 
+import dk.cachet.carp.common.application.DefaultUUIDFactory
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.UUIDFactory
 import dk.cachet.carp.common.application.services.ApplicationServiceEventBus
@@ -16,7 +17,7 @@ import kotlinx.datetime.Clock
 class StudyServiceHost(
     private val repository: StudyRepository,
     private val eventBus: ApplicationServiceEventBus<StudyService, StudyService.Event>,
-    private val uuidFactory: UUIDFactory = UUID.Companion,
+    private val uuidFactory: UUIDFactory = DefaultUUIDFactory,
     private val clock: Clock = Clock.System
 ) : StudyService
 {

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyStatus.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.application.UUID
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/AssignedParticipantRoles.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/AssignedParticipantRoles.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.studies.application.users
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AssignedTo
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/Participant.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/Participant.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.studies.application.users
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.studies.domain.Study
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatus.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.domain.StudyDeployment
 import dk.cachet.carp.deployments.domain.users.ParticipantGroup
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -113,8 +113,31 @@ class Study(
      * Get the status (serializable) of this [Study].
      */
     fun getStatus(): StudyStatus =
-        if ( isLive ) StudyStatus.Live( id, name, createdOn, protocolSnapshot?.id, canSetInvitation, canSetStudyProtocol, canDeployToParticipants )
-        else StudyStatus.Configuring( id, name, createdOn, protocolSnapshot?.id, canSetInvitation, canSetStudyProtocol, canDeployToParticipants, canGoLive )
+        if ( isLive )
+        {
+            StudyStatus.Live(
+                id,
+                name,
+                createdOn,
+                protocolSnapshot?.id,
+                canSetInvitation,
+                canSetStudyProtocol,
+                canDeployToParticipants
+            )
+        }
+        else
+        {
+            StudyStatus.Configuring(
+                id,
+                name,
+                createdOn,
+                protocolSnapshot?.id,
+                canSetInvitation,
+                canSetStudyProtocol,
+                canDeployToParticipants,
+                canGoLive
+            )
+        }
 
     /**
      * Get [StudyDetails] for this [Study].

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -166,7 +166,7 @@ class Study(
      */
     fun goLive()
     {
-        check( protocolSnapshot != null ) { "A study protocol needs to be defined for a study to go live." }
+        checkNotNull( protocolSnapshot ) { "A study protocol needs to be defined for a study to go live." }
 
         if ( !isLive )
         {

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -101,8 +101,11 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
     {
         val protocol = studyProtocol
         val invitation = invitation
-        return if ( protocol != null && invitation != null ) RecruitmentStatus.ReadyForDeployment( protocol, invitation )
+        val status =
+            if ( protocol != null && invitation != null ) RecruitmentStatus.ReadyForDeployment( protocol, invitation )
             else RecruitmentStatus.AwaitingStudyToGoLive
+
+        return status
     }
 
     /**
@@ -117,7 +120,9 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
      *  - not all primary devices part of the study protocol have been assigned a participant
      *  - not all necessary participant roles part of the study have been assigned a participant
      */
-    fun createInvitations( group: Set<AssignedParticipantRoles> ): Pair<StudyProtocolSnapshot, List<ParticipantInvitation>>
+    fun createInvitations(
+        group: Set<AssignedParticipantRoles>
+    ): Pair<StudyProtocolSnapshot, List<ParticipantInvitation>>
     {
         val status = getStatus()
         check( status is RecruitmentStatus.ReadyForDeployment )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentSnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentSnapshot.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.studies.application.users.Participant
 import kotlinx.datetime.Instant
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 @Serializable

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentStatus.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroup.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroup.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.UUID
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
@@ -9,10 +9,7 @@ import dk.cachet.carp.studies.application.RecruitmentService
 import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -9,10 +9,7 @@ import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.studies.application.StudyDetails
 import dk.cachet.carp.studies.application.StudyService
 import dk.cachet.carp.studies.application.StudyStatus
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
+import kotlinx.serialization.*
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/StudyServiceApiMigrator.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/StudyServiceApiMigrator.kt
@@ -7,8 +7,7 @@ import dk.cachet.carp.common.infrastructure.versioning.Major1Minor0To1Migration
 import dk.cachet.carp.common.infrastructure.versioning.getType
 import dk.cachet.carp.studies.application.StudyService
 import dk.cachet.carp.studies.infrastructure.StudyServiceRequest
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.*
 
 
 private val major1Minor0To1Migration =

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/AssignedParticipantRolesTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/AssignedParticipantRolesTest.kt
@@ -4,8 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantTest.kt
@@ -3,8 +3,7 @@ package dk.cachet.carp.studies.infrastructure
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.studies.application.users.Participant
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyStatusTest.kt
@@ -4,8 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.studies.application.StudyStatus
 import kotlinx.datetime.Clock
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
@@ -2,10 +2,7 @@
 
 package dk.cachet.carp.test.serialization
 
-import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.SerializersModuleCollector

--- a/detekt.yml
+++ b/detekt.yml
@@ -72,10 +72,7 @@ style:
   UnusedPrivateClass:
     active: false
   WildcardImport:
-    # TODO: Consider deactivating this. The advantages of forcing individual types to be imported are limited.
-    #       Namespaces are supposed to be cohesive sets of objects, thus importing them as a group makes sense.
-    excludes: []
-    excludeImports: ['kotlin.reflect.*', 'kotlin.test.*']
+    active: false
 
 verify-implementation:
   DataClass:

--- a/detekt.yml
+++ b/detekt.yml
@@ -6,13 +6,13 @@ complexity:
 
 formatting:
   ArgumentListWrapping:
-    active: false
+    excludes: ['**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/test/**']
   Filename:
     active: false
   Indentation:
     active: false
   MaximumLineLength:
-    active: false
+    excludes: ['**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/test/**']
   MultiLineIfElse:
     active: false
   NoConsecutiveBlankLines:

--- a/detekt.yml
+++ b/detekt.yml
@@ -5,11 +5,15 @@ complexity:
     ignorePrivate: true
 
 formatting:
+  ArgumentListWrapping:
+    active: false
   Filename:
     active: false
   Indentation:
     active: false
   MaximumLineLength:
+    active: false
+  MultiLineIfElse:
     active: false
   NoConsecutiveBlankLines:
     active: false
@@ -24,6 +28,10 @@ formatting:
   SpacingAroundKeyword:
     active: false
   SpacingAroundParens:
+    active: false
+  SpacingBetweenDeclarationsWithAnnotations:
+    active: false
+  SpacingBetweenDeclarationsWithComments:
     active: false
 
 naming:

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
@@ -12,46 +17,62 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
-"@nodelib/fs.scandir@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
-  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+"@leichtgewicht/ip-codec@^2.0.1":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
+  integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
+  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
   dependencies:
-    "@nodelib/fs.stat" "2.0.5"
-    run-parallel "^1.1.9"
+    "@types/connect" "*"
+    "@types/node" "*"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
-  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.walk@^1.2.3":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
-  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+"@types/bonjour@^3.5.9":
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.10.tgz#0f6aadfe00ea414edc86f5d106357cda9701e275"
+  integrity sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.5"
-    fastq "^1.6.0"
+    "@types/node" "*"
 
-"@types/component-emitter@^1.2.10":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.11.tgz#50d47d42b347253817a39709fef03ce66a108506"
-  integrity sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==
+"@types/connect-history-api-fallback@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
+  integrity sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/node" "*"
 
-"@types/cookie@^0.4.0":
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
-"@types/cors@^2.8.8":
-  version "2.8.12"
-  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
-  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+"@types/cors@^2.8.12":
+  version "2.8.13"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"
+  integrity sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==
+  dependencies:
+    "@types/node" "*"
 
-"@types/eslint-scope@^3.7.0":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.2.tgz#11e96a868c67acf65bf6f11d10bb89ea71d5e473"
-  integrity sha512-TzgYCWoPiTeRg6RQYgtuW7iODtVoKu3RVL72k3WohqhjfaOLK5Mg2T4Tg1o2bSfu0vPkoI48wdQFv5b/Xe04wQ==
+"@types/eslint-scope@^3.7.3":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
+  integrity sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==
   dependencies:
     "@types/eslint" "*"
     "@types/estree" "*"
@@ -64,15 +85,39 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^0.0.50":
+"@types/estree@*":
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
-"@types/http-proxy@^1.17.5":
-  version "1.17.8"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.8.tgz#968c66903e7e42b483608030ee85800f22d03f55"
-  integrity sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==
+"@types/estree@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.31":
+  version "4.17.31"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
+  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*", "@types/express@^4.17.13":
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
+  integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.31"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/http-proxy@^1.17.8":
+  version "1.17.9"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.9.tgz#7f0e7931343761efde1e2bf48c40f02f3f75705a"
+  integrity sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
   dependencies:
     "@types/node" "*"
 
@@ -81,15 +126,59 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/mime@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
 "@types/node@*", "@types/node@>=10.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.0.tgz#62797cee3b8b497f6547503b2312254d4fe3c2bb"
   integrity sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==
 
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
 "@types/retry@^0.12.0":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
+
+"@types/serve-index@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
+  integrity sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==
+  dependencies:
+    "@types/express" "*"
+
+"@types/serve-static@*", "@types/serve-static@^1.13.10":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
+  integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
+
+"@types/sockjs@^0.3.33":
+  version "0.3.33"
+  resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
+  integrity sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.5.1":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -217,22 +306,22 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.0.tgz#8342bef0badfb7dfd3b576f2574ab80c725be043"
-  integrity sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==
+"@webpack-cli/configtest@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.2.0.tgz#7b20ce1c12533912c3b217ea68262365fa29a6f5"
+  integrity sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
 
-"@webpack-cli/info@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.0.tgz#b9179c3227ab09cbbb149aa733475fcf99430223"
-  integrity sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==
+"@webpack-cli/info@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.5.0.tgz#6c78c13c5874852d6e2dd17f08a41f3fe4c261b1"
+  integrity sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
   dependencies:
     envinfo "^7.7.3"
 
-"@webpack-cli/serve@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
-  integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
+"@webpack-cli/serve@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
+  integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -244,12 +333,12 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
-  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
-accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
+accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -257,23 +346,23 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
+
 acorn-import-assertions@^1.7.6:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
-acorn@^8.4.1:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
-  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
-
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
+acorn@^8.7.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 ajv-formats@^2.1.1:
   version "2.1.1"
@@ -329,11 +418,6 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
-
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
@@ -359,32 +443,15 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
-array-flatten@^2.1.0:
+array-flatten@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
-
-array-union@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
-  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-base64-arraybuffer@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
-  integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
 base64id@2.0.0, base64id@~2.0.0:
   version "2.0.0"
@@ -406,7 +473,25 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-body-parser@1.19.1, body-parser@^1.19.0:
+body-parser@1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
+  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
+body-parser@^1.19.0:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.1.tgz#1499abbaa9274af3ecc9f6f10396c995943e31d4"
   integrity sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==
@@ -422,17 +507,15 @@ body-parser@1.19.1, body-parser@^1.19.0:
     raw-body "2.4.2"
     type-is "~1.6.18"
 
-bonjour@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
-  integrity sha1-jokKGD2O6aI5OzhExpGkK897yfU=
+bonjour-service@^1.0.11:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.0.14.tgz#c346f5bc84e87802d08f8d5a60b93f758e514ee7"
+  integrity sha512-HIMbgLnk1Vqvs6B4Wq5ep7mxvj9sGz5d1JJyDNSGNIdA/w2MCz6GTjWTdjqOJV1bEPj+6IkxDvWNFKEBxNt4kQ==
   dependencies:
-    array-flatten "^2.1.0"
-    deep-equal "^1.0.1"
+    array-flatten "^2.1.2"
     dns-equal "^1.0.0"
-    dns-txt "^2.0.2"
-    multicast-dns "^6.0.1"
-    multicast-dns-service-types "^1.1.0"
+    fast-deep-equal "^3.1.3"
+    multicast-dns "^7.2.5"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -441,6 +524,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
@@ -470,11 +560,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer-indexof@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
-  integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -485,7 +570,12 @@ bytes@3.1.1:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
   integrity sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==
 
-call-bind@^1.0.2:
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+call-bind@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -511,7 +601,22 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.5.2, chokidar@^3.5.1:
+chokidar@3.5.3, chokidar@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -530,11 +635,6 @@ chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
-
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -571,11 +671,6 @@ colorette@^2.0.10, colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -585,11 +680,6 @@ commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
-
-component-emitter@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -616,10 +706,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-connect-history-api-fallback@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
-  integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+connect-history-api-fallback@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
+  integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
 
 connect@^3.7.0:
   version "3.7.0"
@@ -648,7 +738,12 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.1, cookie@~0.4.1:
+cookie@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
@@ -680,15 +775,10 @@ custom-event@~1.0.0:
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
   integrity sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
 
-date-format@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
-  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
-
-date-format@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-3.0.0.tgz#eb8780365c7d2b1511078fb491e6479780f3ad95"
-  integrity sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==
+date-format@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.14.tgz#7a8e584434fb169a521c8b7aa481f355810d9400"
+  integrity sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==
 
 debug@2.6.9:
   version "2.6.9"
@@ -697,21 +787,14 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+debug@4.3.4, debug@^4.3.4, debug@~4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.1:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1, debug@~4.3.1:
+debug@^4.1.0, debug@~4.3.1:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -723,19 +806,7 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-deep-equal@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
-  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
-  dependencies:
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.1"
-    is-regex "^1.0.4"
-    object-is "^1.0.1"
-    object-keys "^1.1.1"
-    regexp.prototype.flags "^1.2.0"
-
-default-gateway@^6.0.0:
+default-gateway@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
   integrity sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==
@@ -747,36 +818,20 @@ define-lazy-prop@^2.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
-define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
-  dependencies:
-    object-keys "^1.0.12"
-
-del@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
-  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
-  dependencies:
-    globby "^11.0.1"
-    graceful-fs "^4.2.4"
-    is-glob "^4.0.1"
-    is-path-cwd "^2.2.0"
-    is-path-inside "^3.0.2"
-    p-map "^4.0.0"
-    rimraf "^3.0.2"
-    slash "^3.0.0"
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-destroy@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
-  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+destroy@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 detect-node@^2.0.4:
   version "2.1.0"
@@ -793,32 +848,17 @@ diff@5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
-dir-glob@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
-  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
-  dependencies:
-    path-type "^4.0.0"
-
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-dns-packet@^1.3.1:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
-  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
+dns-packet@^5.2.2:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.4.0.tgz#1f88477cf9f27e78a213fb6d118ae38e759a879b"
+  integrity sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==
   dependencies:
-    ip "^1.1.0"
-    safe-buffer "^5.0.1"
-
-dns-txt@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
-  integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
-  dependencies:
-    buffer-indexof "^1.0.0"
+    "@leichtgewicht/ip-codec" "^2.0.1"
 
 dom-serialize@^2.2.1:
   version "2.2.1"
@@ -858,30 +898,31 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-engine.io-parser@~4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-4.0.3.tgz#83d3a17acfd4226f19e721bb22a1ee8f7662d2f6"
-  integrity sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==
-  dependencies:
-    base64-arraybuffer "0.1.4"
+engine.io-parser@~5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.4.tgz#0b13f704fa9271b3ec4f33112410d8f3f41d0fc0"
+  integrity sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==
 
-engine.io@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-4.1.1.tgz#9a8f8a5ac5a5ea316183c489bf7f5b6cf91ace5b"
-  integrity sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==
+engine.io@~6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.2.1.tgz#e3f7826ebc4140db9bbaa9021ad6b1efb175878f"
+  integrity sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==
   dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
     accepts "~1.3.4"
     base64id "2.0.0"
     cookie "~0.4.1"
     cors "~2.8.5"
     debug "~4.3.1"
-    engine.io-parser "~4.0.0"
-    ws "~7.4.2"
+    engine.io-parser "~5.0.3"
+    ws "~8.2.3"
 
-enhanced-resolve@^5.8.3:
-  version "5.8.3"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
-  integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
+enhanced-resolve@^5.10.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
+  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -971,38 +1012,39 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-express@^4.17.1:
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.17.2.tgz#c18369f265297319beed4e5558753cc8c1364cb3"
-  integrity sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==
+express@^4.17.3:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
+  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
   dependencies:
-    accepts "~1.3.7"
+    accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "1.19.1"
+    body-parser "1.20.1"
     content-disposition "0.5.4"
     content-type "~1.0.4"
-    cookie "0.4.1"
+    cookie "0.5.0"
     cookie-signature "1.0.6"
     debug "2.6.9"
-    depd "~1.1.2"
+    depd "2.0.0"
     encodeurl "~1.0.2"
     escape-html "~1.0.3"
     etag "~1.8.1"
-    finalhandler "~1.1.2"
+    finalhandler "1.2.0"
     fresh "0.5.2"
+    http-errors "2.0.0"
     merge-descriptors "1.0.1"
     methods "~1.1.2"
-    on-finished "~2.3.0"
+    on-finished "2.4.1"
     parseurl "~1.3.3"
     path-to-regexp "0.1.7"
     proxy-addr "~2.0.7"
-    qs "6.9.6"
+    qs "6.11.0"
     range-parser "~1.2.1"
     safe-buffer "5.2.1"
-    send "0.17.2"
-    serve-static "1.14.2"
+    send "0.18.0"
+    serve-static "1.15.0"
     setprototypeof "1.2.0"
-    statuses "~1.5.0"
+    statuses "2.0.1"
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
@@ -1017,17 +1059,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1037,13 +1068,6 @@ fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
-
-fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
-  dependencies:
-    reusify "^1.0.4"
 
 faye-websocket@^0.11.3:
   version "0.11.4"
@@ -1059,7 +1083,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-finalhandler@1.1.2, finalhandler@~1.1.2:
+finalhandler@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
   integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
@@ -1070,6 +1094,19 @@ finalhandler@1.1.2, finalhandler@~1.1.2:
     on-finished "~2.3.0"
     parseurl "~1.3.3"
     statuses "~1.5.0"
+    unpipe "~1.0.0"
+
+finalhandler@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
+  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    statuses "2.0.1"
     unpipe "~1.0.0"
 
 find-up@5.0.0:
@@ -1093,10 +1130,10 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+flatted@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 follow-redirects@^1.0.0:
   version "1.14.6"
@@ -1127,7 +1164,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-monkey@1.0.3:
+fs-monkey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
   integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
@@ -1166,7 +1203,7 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1178,19 +1215,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.1.7:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3, glob@^7.1.7:
+glob@7.2.0, glob@^7.1.3, glob@^7.1.7:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -1202,18 +1227,6 @@ glob@^7.1.3, glob@^7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globby@^11.0.1:
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
-  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
-
 google-protobuf@3.12.2:
   version "3.12.2"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.12.2.tgz#50ce9f9b6281235724eb243d6a83e969a2176e53"
@@ -1224,10 +1237,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-growl@1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 handle-thing@^2.0.0:
   version "2.0.1"
@@ -1239,17 +1252,10 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
+has-symbols@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
-
-has-tostringtag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
-  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
-  dependencies:
-    has-symbols "^1.0.2"
 
 has@^1.0.3:
   version "1.0.3"
@@ -1294,6 +1300,17 @@ http-errors@1.8.1:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
+http-errors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
+  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  dependencies:
+    depd "2.0.0"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    toidentifier "1.0.1"
+
 http-errors@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -1309,12 +1326,12 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.5.tgz#d7c30d5d3c90d865b4a2e870181f9d6f22ac7ac5"
   integrity sha512-x+JVEkO2PoM8qqpbPbOL3cqHPwerep7OwzK7Ay+sMQjKzaKCqWvjoXm5tqMP9tXWWTnTzAjIhXg+J99XYuPhPA==
 
-http-proxy-middleware@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz#7ef3417a479fb7666a571e09966c66a39bd2c15f"
-  integrity sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==
+http-proxy-middleware@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
+  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
   dependencies:
-    "@types/http-proxy" "^1.17.5"
+    "@types/http-proxy" "^1.17.8"
     http-proxy "^1.18.1"
     is-glob "^4.0.1"
     is-plain-obj "^3.0.0"
@@ -1341,17 +1358,12 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
-
-ignore@^5.1.4:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
-  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
 import-local@^3.0.2:
   version "3.0.3"
@@ -1360,11 +1372,6 @@ import-local@^3.0.2:
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
-
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1384,32 +1391,12 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-internal-ip@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-6.2.0.tgz#d5541e79716e406b74ac6b07b856ef18dc1621c1"
-  integrity sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==
-  dependencies:
-    default-gateway "^6.0.0"
-    ipaddr.js "^1.9.1"
-    is-ip "^3.1.0"
-    p-event "^4.2.0"
-
 interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-ip-regex@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
-  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
-
-ip@^1.1.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
-
-ipaddr.js@1.9.1, ipaddr.js@^1.9.1:
+ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
@@ -1418,14 +1405,6 @@ ipaddr.js@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
   integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
-
-is-arguments@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -1440,13 +1419,6 @@ is-core-module@^2.2.0:
   integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
   dependencies:
     has "^1.0.3"
-
-is-date-object@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
-  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
-  dependencies:
-    has-tostringtag "^1.0.0"
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
@@ -1470,27 +1442,10 @@ is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-ip@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
-  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
-  dependencies:
-    ip-regex "^4.0.0"
-
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
-is-path-cwd@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
-  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
-
-is-path-inside@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
-  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.1.0:
   version "2.1.0"
@@ -1508,14 +1463,6 @@ is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
-
-is-regex@^1.0.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
-  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -1570,10 +1517,10 @@ js-yaml@4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-json-parse-better-errors@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+json-parse-even-better-errors@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -1592,10 +1539,10 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-karma-chrome-launcher@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
-  integrity sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==
+karma-chrome-launcher@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.1.tgz#baca9cc071b1562a1db241827257bfe5cab597ea"
+  integrity sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==
   dependencies:
     which "^1.2.1"
 
@@ -1622,15 +1569,15 @@ karma-webpack@5.0.0:
     minimatch "^3.0.4"
     webpack-merge "^4.1.5"
 
-karma@6.3.4:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.3.4.tgz#359899d3aab3d6b918ea0f57046fd2a6b68565e6"
-  integrity sha512-hbhRogUYIulfkBTZT7xoPrCYhRBnBoqbbL4fszWD0ReFGUxU+LYBr3dwKdAluaDQ/ynT9/7C+Lf7pPNW4gSx4Q==
+karma@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.0.tgz#82652dfecdd853ec227b74ed718a997028a99508"
+  integrity sha512-s8m7z0IF5g/bS5ONT7wsOavhW4i4aFkzD4u4wgzAQWT4HGUeWI3i21cK2Yz6jndMAeHETp5XuNsRoyGJZXVd4w==
   dependencies:
+    "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
     braces "^3.0.2"
     chokidar "^3.5.1"
-    colors "^1.4.0"
     connect "^3.7.0"
     di "^0.0.1"
     dom-serialize "^2.2.1"
@@ -1639,16 +1586,17 @@ karma@6.3.4:
     http-proxy "^1.18.1"
     isbinaryfile "^4.0.8"
     lodash "^4.17.21"
-    log4js "^6.3.0"
+    log4js "^6.4.1"
     mime "^2.5.2"
     minimatch "^3.0.4"
+    mkdirp "^0.5.5"
     qjobs "^1.2.0"
     range-parser "^1.2.1"
     rimraf "^3.0.2"
-    socket.io "^3.1.0"
+    socket.io "^4.4.1"
     source-map "^0.6.1"
     tmp "^0.2.1"
-    ua-parser-js "^0.7.28"
+    ua-parser-js "^0.7.30"
     yargs "^16.1.1"
 
 kind-of@^6.0.2:
@@ -1675,7 +1623,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -1688,28 +1636,28 @@ log-symbols@4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-log4js@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.3.0.tgz#10dfafbb434351a3e30277a00b9879446f715bcb"
-  integrity sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==
+log4js@^6.4.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.7.1.tgz#06e12b1ac915dd1067146ffad8215f666f7d2c51"
+  integrity sha512-lzbd0Eq1HRdWM2abSD7mk6YIVY0AogGJzb/z+lqzRk+8+XJP+M6L1MS5FUSc3jjGru4dbKjEMJmqlsoYYpuivQ==
   dependencies:
-    date-format "^3.0.0"
-    debug "^4.1.1"
-    flatted "^2.0.1"
-    rfdc "^1.1.4"
-    streamroller "^2.2.4"
+    date-format "^4.0.14"
+    debug "^4.3.4"
+    flatted "^3.2.7"
+    rfdc "^1.3.0"
+    streamroller "^3.1.3"
 
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memfs@^3.2.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.0.tgz#8bc12062b973be6b295d4340595736a656f0a257"
-  integrity sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==
+memfs@^3.4.3:
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.12.tgz#d00f8ad8dab132dc277c659dc85bfd14b07d03bd"
+  integrity sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==
   dependencies:
-    fs-monkey "1.0.3"
+    fs-monkey "^1.0.3"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -1721,17 +1669,12 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -1744,12 +1687,24 @@ mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
     mime-db "1.51.0"
+
+mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -1771,7 +1726,14 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@3.0.4, minimatch@^3.0.4:
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -1790,32 +1752,30 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.5"
 
-mocha@9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.1.2.tgz#93f53175b0f0dc4014bd2d612218fccfcf3534d3"
-  integrity sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==
+mocha@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
+  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
-    chokidar "3.5.2"
-    debug "4.3.2"
+    chokidar "3.5.3"
+    debug "4.3.4"
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.1.7"
-    growl "1.10.5"
+    glob "7.2.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
-    minimatch "3.0.4"
+    minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.1.25"
+    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
-    which "2.0.2"
-    workerpool "6.1.5"
+    workerpool "6.2.1"
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
@@ -1830,43 +1790,43 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multicast-dns-service-types@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
-  integrity sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=
-
-multicast-dns@^6.0.1:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.3.tgz#a0ec7bd9055c4282f790c3c82f4e28db3b31b229"
-  integrity sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==
+multicast-dns@^7.2.5:
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-7.2.5.tgz#77eb46057f4d7adbd16d9290fa7299f6fa64cced"
+  integrity sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==
   dependencies:
-    dns-packet "^1.3.1"
+    dns-packet "^5.2.2"
     thunky "^1.0.2"
 
-nanoid@3.1.25:
-  version "3.1.25"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
-  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
 neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-releases@^2.0.1:
   version "2.0.1"
@@ -1890,23 +1850,22 @@ object-assign@^4:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-is@^1.0.1:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-
-object-keys@^1.0.12, object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
-  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+on-finished@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -1943,18 +1902,6 @@ open@^8.0.9:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-p-event@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
-  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
-  dependencies:
-    p-timeout "^3.1.0"
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -1983,13 +1930,6 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
-
 p-retry@^4.5.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c"
@@ -1997,13 +1937,6 @@ p-retry@^4.5.0:
   dependencies:
     "@types/retry" "^0.12.0"
     retry "^0.13.1"
-
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2040,11 +1973,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-type@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
-  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -2062,15 +1990,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-portfinder@^1.0.28:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
-  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
-  dependencies:
-    async "^2.6.2"
-    debug "^3.1.1"
-    mkdirp "^0.5.5"
-
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -2084,11 +2003,6 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -2099,20 +2013,17 @@ qjobs@^1.2.0:
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.2.0.tgz#c45e9c61800bd087ef88d7e256423bdd49e5d071"
   integrity sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==
 
+qs@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@6.9.6:
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-queue-microtask@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
-  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -2133,6 +2044,16 @@ raw-body@2.4.2:
   dependencies:
     bytes "3.1.1"
     http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
+  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
@@ -2171,14 +2092,6 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
-
-regexp.prototype.flags@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
-  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -2220,12 +2133,7 @@ retry@^0.13.1:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
-reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rfdc@^1.1.4:
+rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
@@ -2237,19 +2145,12 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-run-parallel@^1.1.9:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
-  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
-  dependencies:
-    queue-microtask "^1.2.2"
-
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2283,31 +2184,31 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.11:
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.11.tgz#24929cd906fe0f44b6d01fb23999a739537acbe9"
-  integrity sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==
+selfsigned@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.1.1.tgz#18a7613d714c0cd3385c48af0075abf3f266af61"
+  integrity sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==
   dependencies:
-    node-forge "^0.10.0"
+    node-forge "^1"
 
-send@0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820"
-  integrity sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==
+send@0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
+  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
   dependencies:
     debug "2.6.9"
-    depd "~1.1.2"
-    destroy "~1.0.4"
+    depd "2.0.0"
+    destroy "1.2.0"
     encodeurl "~1.0.2"
     escape-html "~1.0.3"
     etag "~1.8.1"
     fresh "0.5.2"
-    http-errors "1.8.1"
+    http-errors "2.0.0"
     mime "1.6.0"
     ms "2.1.3"
-    on-finished "~2.3.0"
+    on-finished "2.4.1"
     range-parser "~1.2.1"
-    statuses "~1.5.0"
+    statuses "2.0.1"
 
 serialize-javascript@6.0.0, serialize-javascript@^6.0.0:
   version "6.0.0"
@@ -2329,15 +2230,15 @@ serve-index@^1.9.1:
     mime-types "~2.1.17"
     parseurl "~1.3.2"
 
-serve-static@1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.2.tgz#722d6294b1d62626d41b43a013ece4598d292bfa"
-  integrity sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==
+serve-static@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
+  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
   dependencies:
     encodeurl "~1.0.2"
     escape-html "~1.0.3"
     parseurl "~1.3.3"
-    send "0.17.2"
+    send "0.18.0"
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -2368,46 +2269,46 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.3:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
-slash@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
-  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+socket.io-adapter@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
+  integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
 
-socket.io-adapter@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz#edc5dc36602f2985918d631c1399215e97a1b527"
-  integrity sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==
-
-socket.io-parser@~4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
-  integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+socket.io-parser@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.1.tgz#01c96efa11ded938dcb21cbe590c26af5eff65e5"
+  integrity sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==
   dependencies:
-    "@types/component-emitter" "^1.2.10"
-    component-emitter "~1.3.0"
+    "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
-socket.io@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-3.1.2.tgz#06e27caa1c4fc9617547acfbb5da9bc1747da39a"
-  integrity sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==
+socket.io@^4.4.1:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.4.tgz#a4513f06e87451c17013b8d13fdfaf8da5a86a90"
+  integrity sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==
   dependencies:
-    "@types/cookie" "^0.4.0"
-    "@types/cors" "^2.8.8"
-    "@types/node" ">=10.0.0"
     accepts "~1.3.4"
     base64id "~2.0.0"
-    debug "~4.3.1"
-    engine.io "~4.1.0"
-    socket.io-adapter "~2.1.0"
-    socket.io-parser "~4.0.3"
+    debug "~4.3.2"
+    engine.io "~6.2.1"
+    socket.io-adapter "~2.4.0"
+    socket.io-parser "~4.2.1"
 
-sockjs@^0.3.21:
+sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
   integrity sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==
@@ -2416,19 +2317,19 @@ sockjs@^0.3.21:
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
 
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-source-map-loader@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-3.0.0.tgz#f2a04ee2808ad01c774dea6b7d2639839f3b3049"
-  integrity sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==
+source-map-loader@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.0.tgz#bdc6b118bc6c87ee4d8d851f2d4efcc5abdb2ef5"
+  integrity sha512-i3KVgM3+QPAHNbGavK+VBq03YoJl24m9JWNbLgsjTj8aJzXG9M61bantBTNBt7CNwY2FYf+RJRYJ3pzalKjIrw==
   dependencies:
-    abab "^2.0.5"
-    iconv-lite "^0.6.2"
-    source-map-js "^0.6.2"
+    abab "^2.0.6"
+    iconv-lite "^0.6.3"
+    source-map-js "^1.0.2"
 
 source-map-support@~0.5.20:
   version "0.5.21"
@@ -2471,18 +2372,23 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-streamroller@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-2.2.4.tgz#c198ced42db94086a6193608187ce80a5f2b0e53"
-  integrity sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==
+streamroller@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.1.3.tgz#d95689a8c29b30d093525d0baffe6616fd62ca7e"
+  integrity sha512-CphIJyFx2SALGHeINanjFRKQ4l7x2c+rXYJ4BMq0gd+ZK0gi4VT8b+eHe2wi58x4UayBAKx4xtHpXT/ea1cz8w==
   dependencies:
-    date-format "^2.1.0"
-    debug "^4.1.1"
+    date-format "^4.0.14"
+    debug "^4.3.4"
     fs-extra "^8.1.0"
 
 string-width@^4.1.0, string-width@^4.2.0:
@@ -2514,13 +2420,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-ansi@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
-  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
-  dependencies:
-    ansi-regex "^6.0.1"
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
@@ -2608,10 +2507,10 @@ typescript@3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
-ua-parser-js@^0.7.28:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
-  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+ua-parser-js@^0.7.30:
+  version "0.7.32"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.32.tgz#cd8c639cdca949e30fa68c44b7813ef13e36d211"
+  integrity sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -2630,14 +2529,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -2653,11 +2544,6 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-compile-cache@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -2668,10 +2554,10 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-watchpack@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.1.tgz#4200d9447b401156eeca7767ee610f8809bc9d25"
-  integrity sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==
+watchpack@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -2683,66 +2569,69 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webpack-cli@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.0.tgz#dc43e6e0f80dd52e89cbf73d5294bcd7ad6eb343"
-  integrity sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==
+webpack-cli@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
+  integrity sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^1.1.0"
-    "@webpack-cli/info" "^1.4.0"
-    "@webpack-cli/serve" "^1.6.0"
+    "@webpack-cli/configtest" "^1.2.0"
+    "@webpack-cli/info" "^1.5.0"
+    "@webpack-cli/serve" "^1.7.0"
     colorette "^2.0.14"
     commander "^7.0.0"
-    execa "^5.0.0"
+    cross-spawn "^7.0.3"
     fastest-levenshtein "^1.0.12"
     import-local "^3.0.2"
     interpret "^2.2.0"
     rechoir "^0.7.0"
-    v8-compile-cache "^2.2.0"
     webpack-merge "^5.7.3"
 
-webpack-dev-middleware@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz#8fc02dba6e72e1d373eca361623d84610f27be7c"
-  integrity sha512-MouJz+rXAm9B1OTOYaJnn6rtD/lWZPy2ufQCH3BPs8Rloh/Du6Jze4p7AeLYHkVi0giJnYLaSGDC7S+GM9arhg==
+webpack-dev-middleware@^5.3.1:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
+  integrity sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
   dependencies:
     colorette "^2.0.10"
-    memfs "^3.2.2"
+    memfs "^3.4.3"
     mime-types "^2.1.31"
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz#759d3337f0fbea297fbd1e433ab04ccfc000076b"
-  integrity sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==
+webpack-dev-server@4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz#2360a5d6d532acb5410a668417ad549ee3b8a3c9"
+  integrity sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==
   dependencies:
+    "@types/bonjour" "^3.5.9"
+    "@types/connect-history-api-fallback" "^1.3.5"
+    "@types/express" "^4.17.13"
+    "@types/serve-index" "^1.9.1"
+    "@types/serve-static" "^1.13.10"
+    "@types/sockjs" "^0.3.33"
+    "@types/ws" "^8.5.1"
     ansi-html-community "^0.0.8"
-    bonjour "^3.5.0"
-    chokidar "^3.5.1"
+    bonjour-service "^1.0.11"
+    chokidar "^3.5.3"
     colorette "^2.0.10"
     compression "^1.7.4"
-    connect-history-api-fallback "^1.6.0"
-    del "^6.0.0"
-    express "^4.17.1"
+    connect-history-api-fallback "^2.0.0"
+    default-gateway "^6.0.3"
+    express "^4.17.3"
     graceful-fs "^4.2.6"
     html-entities "^2.3.2"
-    http-proxy-middleware "^2.0.0"
-    internal-ip "^6.2.0"
+    http-proxy-middleware "^2.0.3"
     ipaddr.js "^2.0.1"
     open "^8.0.9"
     p-retry "^4.5.0"
-    portfinder "^1.0.28"
-    schema-utils "^3.1.0"
-    selfsigned "^1.10.11"
+    rimraf "^3.0.2"
+    schema-utils "^4.0.0"
+    selfsigned "^2.0.1"
     serve-index "^1.9.1"
-    sockjs "^0.3.21"
+    sockjs "^0.3.24"
     spdy "^4.0.2"
-    strip-ansi "^7.0.0"
-    url "^0.11.0"
-    webpack-dev-middleware "^5.2.1"
-    ws "^8.1.0"
+    webpack-dev-middleware "^5.3.1"
+    ws "^8.4.2"
 
 webpack-merge@^4.1.5:
   version "4.2.2"
@@ -2759,40 +2648,40 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
-  integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.57.1:
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.57.1.tgz#ead5ace2c17ecef2ae8126f143bfeaa7f55eab44"
-  integrity sha512-kHszukYjTPVfCOEyrUthA3jqJwduY/P3eO8I0gMNOZGIQWKAwZftxmp5hq6paophvwo9NoUrcZOecs9ulOyyTg==
+webpack@5.74.0:
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
   dependencies:
-    "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.50"
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
+    acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
+    enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.4"
-    json-parse-better-errors "^1.0.2"
+    graceful-fs "^4.2.9"
+    json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.2.0"
-    webpack-sources "^3.2.0"
+    watchpack "^2.4.0"
+    webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"
@@ -2808,17 +2697,17 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-which@2.0.2, which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
 which@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -2827,10 +2716,10 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
-workerpool@6.1.5:
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
-  integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -2846,15 +2735,15 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^8.1.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.3.0.tgz#7185e252c8973a60d57170175ff55fdbd116070d"
-  integrity sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==
+ws@^8.4.2:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
-ws@~7.4.2:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+ws@~8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -463,10 +463,10 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
-big.js@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.1.1.tgz#63b35b19dc9775c94991ee5db7694880655d5537"
-  integrity sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==
+big.js@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.1.tgz#7205ce763efb17c2e41f26f121c420c6a7c2744f"
+  integrity sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==
 
 binary-extensions@^2.0.0:
   version "2.2.0"

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -3,8 +3,7 @@
     "BooleanLiteralArgument",
     "MagicNumber",
     "MaximumLineLength",
-    "TopLevelPropertyNaming",
-    "WildcardImport"
+    "TopLevelPropertyNaming"
 )
 
 package dk.cachet.carp.rpc

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -1,4 +1,11 @@
-@file:Suppress( "WildcardImport", "MagicNumber", "BooleanLiteralArgument", "TopLevelPropertyNaming" )
+@file:Suppress(
+    "ArgumentListWrapping",
+    "BooleanLiteralArgument",
+    "MagicNumber",
+    "MaximumLineLength",
+    "TopLevelPropertyNaming",
+    "WildcardImport"
+)
 
 package dk.cachet.carp.rpc
 

--- a/rpc/src/test/kotlin/dk/cachet/carp/rpc/GenerateExampleRequestsTest.kt
+++ b/rpc/src/test/kotlin/dk/cachet/carp/rpc/GenerateExampleRequestsTest.kt
@@ -21,10 +21,9 @@ class GenerateExampleRequestsTest
     fun generateExampleRequests_always_generates_same_JSON()
     {
         applicationServices.forEach { service ->
-            val firstRun =
-                exampleApplicationServiceRequests[ service ]!!.associateBy { it.method }
-            val secondRun =
-                generateExampleRequests( service ).associateBy { it.method }
+            val exampleRequests = checkNotNull( exampleApplicationServiceRequests[ service ] )
+            val firstRun = exampleRequests.associateBy { it.method }
+            val secondRun = generateExampleRequests( service ).associateBy { it.method }
 
             firstRun.forEach { (method, firstExample) ->
                 val secondExample = secondRun[ method ]


### PR DESCRIPTION
Closes #388

In addition, while upgrading to the latest detekt, I decided to re-enable the maximum line length rule for main sources. Some of the lines in CARP were excessively long; enforcing this is a good idea.

Wildcard imports are now allowed and some excessive repeated imports have been removed. Closes #225

To shorten `device is AnyPrimaryDeviceConfiguration` there is now a helper method `device.isPrimary()`.